### PR TITLE
Deactivated attribute added to subscription.

### DIFF
--- a/models/subscription.go
+++ b/models/subscription.go
@@ -20,9 +20,17 @@ type Subscription struct {
 	// attributes
 	Attributes *SubscriptionAttributes `json:"attributes,omitempty"`
 
+	// created on
+	// Format: date-time
+	CreatedOn *strfmt.DateTime `json:"created_on,omitempty"`
+
 	// id
 	// Format: uuid
 	ID strfmt.UUID `json:"id,omitempty"`
+
+	// modified on
+	// Format: date-time
+	ModifiedOn *strfmt.DateTime `json:"modified_on,omitempty"`
 
 	// organisation id
 	// Format: uuid
@@ -45,7 +53,15 @@ func (m *Subscription) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateCreatedOn(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateModifiedOn(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -85,6 +101,19 @@ func (m *Subscription) validateAttributes(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *Subscription) validateCreatedOn(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.CreatedOn) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("created_on", "body", "date-time", m.CreatedOn.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *Subscription) validateID(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.ID) { // not required
@@ -92,6 +121,19 @@ func (m *Subscription) validateID(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("id", "body", "uuid", m.ID.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Subscription) validateModifiedOn(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ModifiedOn) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("modified_on", "body", "date-time", m.ModifiedOn.String(), formats); err != nil {
 		return err
 	}
 

--- a/models/subscription_attributes.go
+++ b/models/subscription_attributes.go
@@ -27,6 +27,9 @@ type SubscriptionAttributes struct {
 	// Pattern: ^[A-Za-z0-9 .,@:\/-_]*$
 	CallbackURI string `json:"callback_uri,omitempty"`
 
+	// deactivated
+	Deactivated bool `json:"deactivated,omitempty"`
+
 	// event type
 	// Pattern: ^[A-Za-z_-]*$
 	EventType string `json:"event_type,omitempty"`

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3422,6 +3422,8 @@ definitions:
       event_type:
         type: string
         pattern: ^[A-Za-z_-]*$
+      deactivated:
+        type: boolean
 
   #Organisation records
   #===
@@ -3677,6 +3679,7 @@ definitions:
           $ref: '#/definitions/Role'
       links:
         $ref: '#/definitions/Links'
+
   Subscription:
     type: object
     properties:
@@ -3692,6 +3695,14 @@ definitions:
       organisation_id:
         type: string
         format: uuid
+      created_on:
+        type: string
+        format: 'date-time'
+        x-nullable: true
+      modified_on:
+        type: string
+        format: 'date-time'
+        x-nullable: true
       attributes:
         $ref: "#/definitions/SubscriptionAttributes"
 


### PR DESCRIPTION
New attributes added since required by `platform-tests` for cleaning of deactivated subscription.
Those attributes appear in the `notifications-api` on `backoff` branch but should be made published soon. 