### PR TITLE
Reset body before reusing request

### DIFF
--- a/pkg/form3/client.go
+++ b/pkg/form3/client.go
@@ -55,6 +55,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	res, err := t.underlyingTransport.RoundTrip(req)
+	req, err = resetRequestBody(req)
 
 	if res != nil && (res.StatusCode == 401 || res.StatusCode == 403) {
 
@@ -109,3 +110,15 @@ func NewHttpClient(config *ClientConfig) *http.Client {
 
 	return h
 }
+
+func resetRequestBody(req *http.Request) (*http.Request, error) {
+	newReq := *req
+	body, err := req.GetBody()
+	newReq.Body = body
+	if err != nil {
+		return nil, fmt.Errorf("could not reset request body, error: %v", err)
+	}
+	req = &newReq
+	return req, err
+}
+


### PR DESCRIPTION
Since we are reusing a request where the Body buffer has
already been read, we need to call GetBody() to get a new
copy of the body and copy the request object. This allows
correct reading of the body in the subsequent request
decorated with the Authorization headers.

Without this change, the client sends empty body messages
on the decorated authorized requests.

This only happens when TLS verification is disabled:
http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}