### PR TITLE
Create new request after authorisation

### DIFF
--- a/pkg/form3/client.go
+++ b/pkg/form3/client.go
@@ -120,15 +120,3 @@ func NewHttpClient(config *ClientConfig) *http.Client {
 
 	return h
 }
-
-func resetRequestBody(req *http.Request) (*http.Request, error) {
-	newReq := *req
-	body, err := req.GetBody()
-	newReq.Body = body
-	if err != nil {
-		return nil, fmt.Errorf("could not reset request body, error: %v", err)
-	}
-	req = &newReq
-	return req, err
-}
-

--- a/pkg/form3/client.go
+++ b/pkg/form3/client.go
@@ -1,6 +1,8 @@
 package form3
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 
 	"encoding/json"
@@ -54,48 +56,56 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", t.token))
 	}
 
+	var requestBodyClone io.Reader
+	if req.Body != nil {
+		originalRequestBody, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(originalRequestBody))
+		requestBodyClone = bytes.NewBuffer(originalRequestBody)
+	}
+
 	res, err := t.underlyingTransport.RoundTrip(req)
-	req, err = resetRequestBody(req)
-
 	if res != nil && (res.StatusCode == 401 || res.StatusCode == 403) {
-
 		authRequest, err := http.NewRequest("POST", t.config.HostUrl.String()+t.config.authEndpoint, nil)
-		authRequest.SetBasicAuth(t.config.ClientId, t.config.ClientSecret)
-
 		if err != nil {
 			return nil, fmt.Errorf("could not build auth request, error: %v", err)
 		}
+		authRequest.SetBasicAuth(t.config.ClientId, t.config.ClientSecret)
 
 		authResponse, err := t.underlyingTransport.RoundTrip(authRequest)
-
 		if err != nil {
 			return nil, fmt.Errorf("error authenticating, error: %v", err)
 		}
+		defer authResponse.Body.Close()
 
 		if authResponse.StatusCode != 200 {
 			return nil, fmt.Errorf("non 200 status code getting token, status code: %d", authResponse.StatusCode)
 		}
 
 		authBody, err := ioutil.ReadAll(authResponse.Body)
-
 		if err != nil {
 			return nil, fmt.Errorf("could not read auth response body, error: %v", err)
 		}
 
 		var authJson authJsonResponse
-
 		err = json.Unmarshal(authBody, &authJson)
-
 		if err != nil {
 			return nil, fmt.Errorf("could not parse auth json response, error: %v", err)
 		}
 
 		t.token = authJson.AccessToken
-
 		req.Header.Del("Authorization")
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", t.token))
 
-		return t.underlyingTransport.RoundTrip(req)
+		retryRequest, err := http.NewRequest(req.Method, req.URL.String(), requestBodyClone)
+		if err != nil {
+			return nil, fmt.Errorf("could not build authenticated request, error: %v", err)
+		}
+		retryRequest.Header = req.Header
+		retryRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", t.token))
+
+		return t.underlyingTransport.RoundTrip(retryRequest)
 	}
 
 	return res, err

--- a/pkg/form3/client.go
+++ b/pkg/form3/client.go
@@ -55,6 +55,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	res, err := t.underlyingTransport.RoundTrip(req)
+	req, err = resetRequestBody(req)
 
 	if res != nil && (res.StatusCode == 401 || res.StatusCode == 403) {
 
@@ -109,3 +110,15 @@ func NewHttpClient(config *ClientConfig) *http.Client {
 
 	return h
 }
+
+func resetRequestBody(req *http.Request) (*http.Request, error) {
+	newReq := *req
+	body, err := req.GetBody()
+	newReq.Body = body
+	if err != nil {
+		return nil, fmt.Errorf("could not reset request body, error: %v", err)
+	}
+	req = &newReq
+	return req, err
+}
+

--- a/tests/create_subscriptions_test.go
+++ b/tests/create_subscriptions_test.go
@@ -1,0 +1,39 @@
+package tests
+
+import (
+	"github.com/form3tech-oss/go-form3/pkg/form3"
+	"github.com/form3tech-oss/go-form3/pkg/generated/models"
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestCreateSubscriptions(t *testing.T) {
+	f3 := form3.New()
+
+	organisationId := strfmt.UUID(uuid.MustParse(os.Getenv("FORM3_ORGANISATION_ID")).String())
+	id := strfmt.UUID(uuid.New().String())
+	transport := "http"
+	callbackUri := "https://google.com/callback"
+	eventType := "created"
+	recordType := "PaymentSubmission"
+
+	req := f3.Subscriptions.CreateSubscription()
+	req.WithData(models.Subscription{
+		ID: &id,
+		OrganisationID: &organisationId,
+		Attributes: &models.SubscriptionAttributes{
+			CallbackTransport: &transport,
+			CallbackURI:       &callbackUri,
+			UserID:            strfmt.UUID(uuid.New().String()),
+			EventType: &eventType,
+			RecordType: &recordType,
+		},
+	})
+
+	resp, err := req.Do()
+	require.Nil(t, err)
+	require.Equal(t, id.String(), resp.Data.ID.String())
+}

--- a/tests/create_subscriptions_test.go
+++ b/tests/create_subscriptions_test.go
@@ -36,4 +36,7 @@ func TestCreateSubscriptions(t *testing.T) {
 	resp, err := req.Do()
 	require.Nil(t, err)
 	require.Equal(t, id.String(), resp.Data.ID.String())
+
+	_, err = f3.Subscriptions.DeleteSubscription().WithID(id).WithVersion(0).Do()
+	require.Nil(t, err)
 }


### PR DESCRIPTION
Since we are reusing a request where the Body buffer has
already been read, we need to create a new request and
copy the properties into it. Without this change, the client sends empty body messages
on the decorated authorised requests.

This isn't a problem when TLS client config is overridden as in the k6-tests repo:
http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}

This is because when you set a TLSClientConfig go attempts to be conservative and not set any > alternative round trippers (transport:301). Which means that transport:roundTrip makes the > request (as we skip transport:445), and compensates by resetting the request body.

However, if you don't set TLSClientConfig, transport registers an additional roundtripper for
https (http2noDialH2RoundTripper) which instead handles the requet (transport:445), but
doesn't handle an empty HTTP body so nicely. Instead, it happily sends the request with an
empty body and a Content-Size > 0. This causes most web servers to error and close
the connection.

@janakerman