### PR TITLE
Fixes stack overflow in error scenarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := generate-client
+
 swagger_codegen_version := "v0.19.0"
 
 platform := $(shell uname)

--- a/README.md
+++ b/README.md
@@ -63,3 +63,10 @@ Run `gore -autoimport` then type commands interactively, with completion, histor
 `gorun cmd/sample_scripts/print_organisation_names.go`
 
 See [cmd/sample_scripts](cmd/sample_scripts/) for a small subset of sample scripts
+
+## Updating the Client
+
+Tasks in the `Make` file download and preprocess the latest API swagger version.
+
+* `make install-swagger` to install go-swagger if not already installed.
+* `make` to regenerate the client files.

--- a/pkg/generated/client/a_c_e/create_ace_responses.go
+++ b/pkg/generated/client/a_c_e/create_ace_responses.go
@@ -55,7 +55,7 @@ type CreateAceCreated struct {
 }
 
 func (o *CreateAceCreated) Error() string {
-	return fmt.Sprintf("[POST /security/roles/{role_id}/aces][%d] createAceCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /security/roles/{role_id}/aces][%d] createAceCreated", 201)
 }
 
 func (o *CreateAceCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/a_c_e/delete_ace_responses.go
+++ b/pkg/generated/client/a_c_e/delete_ace_responses.go
@@ -47,7 +47,7 @@ type DeleteAceNoContent struct {
 }
 
 func (o *DeleteAceNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /security/roles/{role_id}/aces/{ace_id}][%d] deleteAceNoContent ", 204)
+	return fmt.Sprintf("[DELETE /security/roles/{role_id}/aces/{ace_id}][%d] deleteAceNoContent", 204)
 }
 
 func (o *DeleteAceNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/a_c_e/get_ace_responses.go
+++ b/pkg/generated/client/a_c_e/get_ace_responses.go
@@ -55,7 +55,7 @@ type GetAceOK struct {
 }
 
 func (o *GetAceOK) Error() string {
-	return fmt.Sprintf("[GET /security/roles/{role_id}/aces/{ace_id}][%d] getAceOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /security/roles/{role_id}/aces/{ace_id}][%d] getAceOK", 200)
 }
 
 func (o *GetAceOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/a_c_e/list_aces_responses.go
+++ b/pkg/generated/client/a_c_e/list_aces_responses.go
@@ -55,7 +55,7 @@ type ListAcesOK struct {
 }
 
 func (o *ListAcesOK) Error() string {
-	return fmt.Sprintf("[GET /security/roles/{role_id}/aces][%d] listAcesOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /security/roles/{role_id}/aces][%d] listAcesOK", 200)
 }
 
 func (o *ListAcesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/accounts/create_account_responses.go
+++ b/pkg/generated/client/accounts/create_account_responses.go
@@ -55,7 +55,7 @@ type CreateAccountCreated struct {
 }
 
 func (o *CreateAccountCreated) Error() string {
-	return fmt.Sprintf("[POST /organisation/accounts][%d] createAccountCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /organisation/accounts][%d] createAccountCreated", 201)
 }
 
 func (o *CreateAccountCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/accounts/delete_account_responses.go
+++ b/pkg/generated/client/accounts/delete_account_responses.go
@@ -47,7 +47,7 @@ type DeleteAccountNoContent struct {
 }
 
 func (o *DeleteAccountNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /organisation/accounts/{id}][%d] deleteAccountNoContent ", 204)
+	return fmt.Sprintf("[DELETE /organisation/accounts/{id}][%d] deleteAccountNoContent", 204)
 }
 
 func (o *DeleteAccountNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/accounts/get_account_responses.go
+++ b/pkg/generated/client/accounts/get_account_responses.go
@@ -55,7 +55,7 @@ type GetAccountOK struct {
 }
 
 func (o *GetAccountOK) Error() string {
-	return fmt.Sprintf("[GET /organisation/accounts/{id}][%d] getAccountOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /organisation/accounts/{id}][%d] getAccountOK", 200)
 }
 
 func (o *GetAccountOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/accounts/get_organisation_accounts_id_events_responses.go
+++ b/pkg/generated/client/accounts/get_organisation_accounts_id_events_responses.go
@@ -55,7 +55,7 @@ type GetOrganisationAccountsIDEventsOK struct {
 }
 
 func (o *GetOrganisationAccountsIDEventsOK) Error() string {
-	return fmt.Sprintf("[GET /organisation/accounts/{id}/events][%d] getOrganisationAccountsIdEventsOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /organisation/accounts/{id}/events][%d] getOrganisationAccountsIdEventsOK", 200)
 }
 
 func (o *GetOrganisationAccountsIDEventsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/accounts/list_accounts_responses.go
+++ b/pkg/generated/client/accounts/list_accounts_responses.go
@@ -55,7 +55,7 @@ type ListAccountsOK struct {
 }
 
 func (o *ListAccountsOK) Error() string {
-	return fmt.Sprintf("[GET /organisation/accounts][%d] listAccountsOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /organisation/accounts][%d] listAccountsOK", 200)
 }
 
 func (o *ListAccountsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/accounts/modify_account_responses.go
+++ b/pkg/generated/client/accounts/modify_account_responses.go
@@ -55,7 +55,7 @@ type ModifyAccountOK struct {
 }
 
 func (o *ModifyAccountOK) Error() string {
-	return fmt.Sprintf("[PATCH /organisation/accounts/{id}][%d] modifyAccountOK  %+v", 200, o)
+	return fmt.Sprintf("[PATCH /organisation/accounts/{id}][%d] modifyAccountOK", 200)
 }
 
 func (o *ModifyAccountOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/audit/get_audit_entry_responses.go
+++ b/pkg/generated/client/audit/get_audit_entry_responses.go
@@ -55,7 +55,7 @@ type GetAuditEntryOK struct {
 }
 
 func (o *GetAuditEntryOK) Error() string {
-	return fmt.Sprintf("[GET /audit/entries/{record_type}/{id}][%d] getAuditEntryOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /audit/entries/{record_type}/{id}][%d] getAuditEntryOK", 200)
 }
 
 func (o *GetAuditEntryOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/audit/get_audit_health_responses.go
+++ b/pkg/generated/client/audit/get_audit_health_responses.go
@@ -55,7 +55,7 @@ type GetAuditHealthOK struct {
 }
 
 func (o *GetAuditHealthOK) Error() string {
-	return fmt.Sprintf("[GET /audit/entries/health][%d] getAuditHealthOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /audit/entries/health][%d] getAuditHealthOK", 200)
 }
 
 func (o *GetAuditHealthOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/audit/list_audit_entries_responses.go
+++ b/pkg/generated/client/audit/list_audit_entries_responses.go
@@ -55,7 +55,7 @@ type ListAuditEntriesOK struct {
 }
 
 func (o *ListAuditEntriesOK) Error() string {
-	return fmt.Sprintf("[GET /audit/entries/{record_type}][%d] listAuditEntriesOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /audit/entries/{record_type}][%d] listAuditEntriesOK", 200)
 }
 
 func (o *ListAuditEntriesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/balances/get_balanced_responses.go
+++ b/pkg/generated/client/balances/get_balanced_responses.go
@@ -55,7 +55,7 @@ type GetBalancedOK struct {
 }
 
 func (o *GetBalancedOK) Error() string {
-	return fmt.Sprintf("[GET /organisation/balances][%d] getBalancedOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /organisation/balances][%d] getBalancedOK", 200)
 }
 
 func (o *GetBalancedOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/claims/create_claim_responses.go
+++ b/pkg/generated/client/claims/create_claim_responses.go
@@ -62,7 +62,7 @@ type CreateClaimCreated struct {
 }
 
 func (o *CreateClaimCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/claims][%d] createClaimCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/claims][%d] createClaimCreated", 201)
 }
 
 func (o *CreateClaimCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateClaimBadRequest struct {
 }
 
 func (o *CreateClaimBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/claims][%d] createClaimBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/claims][%d] createClaimBadRequest", 400)
 }
 
 func (o *CreateClaimBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/claims/create_claim_reversal_responses.go
+++ b/pkg/generated/client/claims/create_claim_reversal_responses.go
@@ -62,7 +62,7 @@ type CreateClaimReversalCreated struct {
 }
 
 func (o *CreateClaimReversalCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/claims/{id}/reversals][%d] createClaimReversalCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/claims/{id}/reversals][%d] createClaimReversalCreated", 201)
 }
 
 func (o *CreateClaimReversalCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateClaimReversalBadRequest struct {
 }
 
 func (o *CreateClaimReversalBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/claims/{id}/reversals][%d] createClaimReversalBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/claims/{id}/reversals][%d] createClaimReversalBadRequest", 400)
 }
 
 func (o *CreateClaimReversalBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/claims/create_claim_reversal_submission_responses.go
+++ b/pkg/generated/client/claims/create_claim_reversal_submission_responses.go
@@ -62,7 +62,7 @@ type CreateClaimReversalSubmissionCreated struct {
 }
 
 func (o *CreateClaimReversalSubmissionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/claims/{id}/reversals/{reversalId}/submissions][%d] createClaimReversalSubmissionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/claims/{id}/reversals/{reversalId}/submissions][%d] createClaimReversalSubmissionCreated", 201)
 }
 
 func (o *CreateClaimReversalSubmissionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateClaimReversalSubmissionBadRequest struct {
 }
 
 func (o *CreateClaimReversalSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/claims/{id}/reversals/{reversalId}/submissions][%d] createClaimReversalSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/claims/{id}/reversals/{reversalId}/submissions][%d] createClaimReversalSubmissionBadRequest", 400)
 }
 
 func (o *CreateClaimReversalSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/claims/create_claim_submission_responses.go
+++ b/pkg/generated/client/claims/create_claim_submission_responses.go
@@ -62,7 +62,7 @@ type CreateClaimSubmissionCreated struct {
 }
 
 func (o *CreateClaimSubmissionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/claims/{id}/submissions][%d] createClaimSubmissionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/claims/{id}/submissions][%d] createClaimSubmissionCreated", 201)
 }
 
 func (o *CreateClaimSubmissionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateClaimSubmissionBadRequest struct {
 }
 
 func (o *CreateClaimSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/claims/{id}/submissions][%d] createClaimSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/claims/{id}/submissions][%d] createClaimSubmissionBadRequest", 400)
 }
 
 func (o *CreateClaimSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/claims/get_claim_responses.go
+++ b/pkg/generated/client/claims/get_claim_responses.go
@@ -55,7 +55,7 @@ type GetClaimOK struct {
 }
 
 func (o *GetClaimOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/claims/{id}][%d] getClaimOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/claims/{id}][%d] getClaimOK", 200)
 }
 
 func (o *GetClaimOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/claims/get_claim_reversal_responses.go
+++ b/pkg/generated/client/claims/get_claim_reversal_responses.go
@@ -62,7 +62,7 @@ type GetClaimReversalOK struct {
 }
 
 func (o *GetClaimReversalOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/claims/{id}/reversals/{reversalId}][%d] getClaimReversalOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/claims/{id}/reversals/{reversalId}][%d] getClaimReversalOK", 200)
 }
 
 func (o *GetClaimReversalOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type GetClaimReversalBadRequest struct {
 }
 
 func (o *GetClaimReversalBadRequest) Error() string {
-	return fmt.Sprintf("[GET /transaction/claims/{id}/reversals/{reversalId}][%d] getClaimReversalBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[GET /transaction/claims/{id}/reversals/{reversalId}][%d] getClaimReversalBadRequest", 400)
 }
 
 func (o *GetClaimReversalBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/claims/get_claim_reversal_submission_responses.go
+++ b/pkg/generated/client/claims/get_claim_reversal_submission_responses.go
@@ -62,7 +62,7 @@ type GetClaimReversalSubmissionOK struct {
 }
 
 func (o *GetClaimReversalSubmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/claims/{id}/reversals/{reversalId}/submissions/{submissionId}][%d] getClaimReversalSubmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/claims/{id}/reversals/{reversalId}/submissions/{submissionId}][%d] getClaimReversalSubmissionOK", 200)
 }
 
 func (o *GetClaimReversalSubmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type GetClaimReversalSubmissionBadRequest struct {
 }
 
 func (o *GetClaimReversalSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[GET /transaction/claims/{id}/reversals/{reversalId}/submissions/{submissionId}][%d] getClaimReversalSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[GET /transaction/claims/{id}/reversals/{reversalId}/submissions/{submissionId}][%d] getClaimReversalSubmissionBadRequest", 400)
 }
 
 func (o *GetClaimReversalSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/claims/get_claim_submission_responses.go
+++ b/pkg/generated/client/claims/get_claim_submission_responses.go
@@ -62,7 +62,7 @@ type GetClaimSubmissionOK struct {
 }
 
 func (o *GetClaimSubmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/claims/{id}/submissions/{submissionId}][%d] getClaimSubmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/claims/{id}/submissions/{submissionId}][%d] getClaimSubmissionOK", 200)
 }
 
 func (o *GetClaimSubmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type GetClaimSubmissionBadRequest struct {
 }
 
 func (o *GetClaimSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[GET /transaction/claims/{id}/submissions/{submissionId}][%d] getClaimSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[GET /transaction/claims/{id}/submissions/{submissionId}][%d] getClaimSubmissionBadRequest", 400)
 }
 
 func (o *GetClaimSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/claims/get_claims_health_responses.go
+++ b/pkg/generated/client/claims/get_claims_health_responses.go
@@ -55,7 +55,7 @@ type GetClaimsHealthOK struct {
 }
 
 func (o *GetClaimsHealthOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/claims/health][%d] getClaimsHealthOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/claims/health][%d] getClaimsHealthOK", 200)
 }
 
 func (o *GetClaimsHealthOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/claims/list_claims_responses.go
+++ b/pkg/generated/client/claims/list_claims_responses.go
@@ -55,7 +55,7 @@ type ListClaimsOK struct {
 }
 
 func (o *ListClaimsOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/claims][%d] listClaimsOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/claims][%d] listClaimsOK", 200)
 }
 
 func (o *ListClaimsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/create_direct_debit_responses.go
+++ b/pkg/generated/client/direct_debits/create_direct_debit_responses.go
@@ -62,7 +62,7 @@ type CreateDirectDebitCreated struct {
 }
 
 func (o *CreateDirectDebitCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/directdebits][%d] createDirectDebitCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/directdebits][%d] createDirectDebitCreated", 201)
 }
 
 func (o *CreateDirectDebitCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateDirectDebitBadRequest struct {
 }
 
 func (o *CreateDirectDebitBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/directdebits][%d] createDirectDebitBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/directdebits][%d] createDirectDebitBadRequest", 400)
 }
 
 func (o *CreateDirectDebitBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/create_direct_debit_return_responses.go
+++ b/pkg/generated/client/direct_debits/create_direct_debit_return_responses.go
@@ -62,7 +62,7 @@ type CreateDirectDebitReturnCreated struct {
 }
 
 func (o *CreateDirectDebitReturnCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/directdebits/{id}/returns][%d] createDirectDebitReturnCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/directdebits/{id}/returns][%d] createDirectDebitReturnCreated", 201)
 }
 
 func (o *CreateDirectDebitReturnCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateDirectDebitReturnBadRequest struct {
 }
 
 func (o *CreateDirectDebitReturnBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/directdebits/{id}/returns][%d] createDirectDebitReturnBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/directdebits/{id}/returns][%d] createDirectDebitReturnBadRequest", 400)
 }
 
 func (o *CreateDirectDebitReturnBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/create_direct_debit_return_submission_responses.go
+++ b/pkg/generated/client/direct_debits/create_direct_debit_return_submission_responses.go
@@ -62,7 +62,7 @@ type CreateDirectDebitReturnSubmissionCreated struct {
 }
 
 func (o *CreateDirectDebitReturnSubmissionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/directdebits/{id}/returns/{returnId}/submissions][%d] createDirectDebitReturnSubmissionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/directdebits/{id}/returns/{returnId}/submissions][%d] createDirectDebitReturnSubmissionCreated", 201)
 }
 
 func (o *CreateDirectDebitReturnSubmissionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateDirectDebitReturnSubmissionBadRequest struct {
 }
 
 func (o *CreateDirectDebitReturnSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/directdebits/{id}/returns/{returnId}/submissions][%d] createDirectDebitReturnSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/directdebits/{id}/returns/{returnId}/submissions][%d] createDirectDebitReturnSubmissionBadRequest", 400)
 }
 
 func (o *CreateDirectDebitReturnSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/create_direct_debit_reversal_responses.go
+++ b/pkg/generated/client/direct_debits/create_direct_debit_reversal_responses.go
@@ -62,7 +62,7 @@ type CreateDirectDebitReversalCreated struct {
 }
 
 func (o *CreateDirectDebitReversalCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/directdebits/{id}/reversals][%d] createDirectDebitReversalCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/directdebits/{id}/reversals][%d] createDirectDebitReversalCreated", 201)
 }
 
 func (o *CreateDirectDebitReversalCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateDirectDebitReversalBadRequest struct {
 }
 
 func (o *CreateDirectDebitReversalBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/directdebits/{id}/reversals][%d] createDirectDebitReversalBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/directdebits/{id}/reversals][%d] createDirectDebitReversalBadRequest", 400)
 }
 
 func (o *CreateDirectDebitReversalBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/create_direct_debit_submission_responses.go
+++ b/pkg/generated/client/direct_debits/create_direct_debit_submission_responses.go
@@ -62,7 +62,7 @@ type CreateDirectDebitSubmissionCreated struct {
 }
 
 func (o *CreateDirectDebitSubmissionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/directdebits/{id}/submissions][%d] createDirectDebitSubmissionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/directdebits/{id}/submissions][%d] createDirectDebitSubmissionCreated", 201)
 }
 
 func (o *CreateDirectDebitSubmissionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateDirectDebitSubmissionBadRequest struct {
 }
 
 func (o *CreateDirectDebitSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/directdebits/{id}/submissions][%d] createDirectDebitSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/directdebits/{id}/submissions][%d] createDirectDebitSubmissionBadRequest", 400)
 }
 
 func (o *CreateDirectDebitSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/get_direct_debit_admission_responses.go
+++ b/pkg/generated/client/direct_debits/get_direct_debit_admission_responses.go
@@ -55,7 +55,7 @@ type GetDirectDebitAdmissionOK struct {
 }
 
 func (o *GetDirectDebitAdmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/directdebits/{id}/admissions/{admissionId}][%d] getDirectDebitAdmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/directdebits/{id}/admissions/{admissionId}][%d] getDirectDebitAdmissionOK", 200)
 }
 
 func (o *GetDirectDebitAdmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/get_direct_debit_health_responses.go
+++ b/pkg/generated/client/direct_debits/get_direct_debit_health_responses.go
@@ -55,7 +55,7 @@ type GetDirectDebitHealthOK struct {
 }
 
 func (o *GetDirectDebitHealthOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/directdebits/health][%d] getDirectDebitHealthOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/directdebits/health][%d] getDirectDebitHealthOK", 200)
 }
 
 func (o *GetDirectDebitHealthOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/get_direct_debit_responses.go
+++ b/pkg/generated/client/direct_debits/get_direct_debit_responses.go
@@ -55,7 +55,7 @@ type GetDirectDebitOK struct {
 }
 
 func (o *GetDirectDebitOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/directdebits/{id}][%d] getDirectDebitOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/directdebits/{id}][%d] getDirectDebitOK", 200)
 }
 
 func (o *GetDirectDebitOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/get_direct_debit_return_responses.go
+++ b/pkg/generated/client/direct_debits/get_direct_debit_return_responses.go
@@ -55,7 +55,7 @@ type GetDirectDebitReturnOK struct {
 }
 
 func (o *GetDirectDebitReturnOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/directdebits/{id}/returns/{returnId}][%d] getDirectDebitReturnOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/directdebits/{id}/returns/{returnId}][%d] getDirectDebitReturnOK", 200)
 }
 
 func (o *GetDirectDebitReturnOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/get_direct_debit_return_submission_responses.go
+++ b/pkg/generated/client/direct_debits/get_direct_debit_return_submission_responses.go
@@ -55,7 +55,7 @@ type GetDirectDebitReturnSubmissionOK struct {
 }
 
 func (o *GetDirectDebitReturnSubmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/directdebits/{id}/returns/{returnId}/submissions/{submissionId}][%d] getDirectDebitReturnSubmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/directdebits/{id}/returns/{returnId}/submissions/{submissionId}][%d] getDirectDebitReturnSubmissionOK", 200)
 }
 
 func (o *GetDirectDebitReturnSubmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/get_direct_debit_reversal_admission_responses.go
+++ b/pkg/generated/client/direct_debits/get_direct_debit_reversal_admission_responses.go
@@ -55,7 +55,7 @@ type GetDirectDebitReversalAdmissionOK struct {
 }
 
 func (o *GetDirectDebitReversalAdmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/directdebits/{id}/reversals/{reversalId}/admissions/{admissionId}][%d] getDirectDebitReversalAdmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/directdebits/{id}/reversals/{reversalId}/admissions/{admissionId}][%d] getDirectDebitReversalAdmissionOK", 200)
 }
 
 func (o *GetDirectDebitReversalAdmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/get_direct_debit_reversal_responses.go
+++ b/pkg/generated/client/direct_debits/get_direct_debit_reversal_responses.go
@@ -55,7 +55,7 @@ type GetDirectDebitReversalOK struct {
 }
 
 func (o *GetDirectDebitReversalOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/directdebits/{id}/reversals/{reversalId}][%d] getDirectDebitReversalOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/directdebits/{id}/reversals/{reversalId}][%d] getDirectDebitReversalOK", 200)
 }
 
 func (o *GetDirectDebitReversalOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/get_direct_debit_submission_responses.go
+++ b/pkg/generated/client/direct_debits/get_direct_debit_submission_responses.go
@@ -55,7 +55,7 @@ type GetDirectDebitSubmissionOK struct {
 }
 
 func (o *GetDirectDebitSubmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/directdebits/{id}/submissions/{submissionId}][%d] getDirectDebitSubmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/directdebits/{id}/submissions/{submissionId}][%d] getDirectDebitSubmissionOK", 200)
 }
 
 func (o *GetDirectDebitSubmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/get_transaction_directdebits_id_returns_return_id_admissions_admission_id_responses.go
+++ b/pkg/generated/client/direct_debits/get_transaction_directdebits_id_returns_return_id_admissions_admission_id_responses.go
@@ -55,7 +55,7 @@ type GetTransactionDirectdebitsIDReturnsReturnIDAdmissionsAdmissionIDOK struct {
 }
 
 func (o *GetTransactionDirectdebitsIDReturnsReturnIDAdmissionsAdmissionIDOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/directdebits/{id}/returns/{returnId}/admissions/{admissionId}][%d] getTransactionDirectdebitsIdReturnsReturnIdAdmissionsAdmissionIdOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/directdebits/{id}/returns/{returnId}/admissions/{admissionId}][%d] getTransactionDirectdebitsIdReturnsReturnIdAdmissionsAdmissionIdOK", 200)
 }
 
 func (o *GetTransactionDirectdebitsIDReturnsReturnIDAdmissionsAdmissionIDOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/get_transaction_directdebits_id_returns_return_id_reversals_reversal_id_admissions_admission_id_responses.go
+++ b/pkg/generated/client/direct_debits/get_transaction_directdebits_id_returns_return_id_reversals_reversal_id_admissions_admission_id_responses.go
@@ -55,7 +55,7 @@ type GetTransactionDirectdebitsIDReturnsReturnIDReversalsReversalIDAdmissionsAdm
 }
 
 func (o *GetTransactionDirectdebitsIDReturnsReturnIDReversalsReversalIDAdmissionsAdmissionIDOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/directdebits/{id}/returns/{returnId}/reversals/{reversalId}/admissions/{admissionId}][%d] getTransactionDirectdebitsIdReturnsReturnIdReversalsReversalIdAdmissionsAdmissionIdOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/directdebits/{id}/returns/{returnId}/reversals/{reversalId}/admissions/{admissionId}][%d] getTransactionDirectdebitsIdReturnsReturnIdReversalsReversalIdAdmissionsAdmissionIdOK", 200)
 }
 
 func (o *GetTransactionDirectdebitsIDReturnsReturnIDReversalsReversalIDAdmissionsAdmissionIDOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/get_transaction_directdebits_id_returns_return_id_reversals_reversal_id_responses.go
+++ b/pkg/generated/client/direct_debits/get_transaction_directdebits_id_returns_return_id_reversals_reversal_id_responses.go
@@ -55,7 +55,7 @@ type GetTransactionDirectdebitsIDReturnsReturnIDReversalsReversalIDOK struct {
 }
 
 func (o *GetTransactionDirectdebitsIDReturnsReturnIDReversalsReversalIDOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/directdebits/{id}/returns/{returnId}/reversals/{reversalId}][%d] getTransactionDirectdebitsIdReturnsReturnIdReversalsReversalIdOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/directdebits/{id}/returns/{returnId}/reversals/{reversalId}][%d] getTransactionDirectdebitsIdReturnsReturnIdReversalsReversalIdOK", 200)
 }
 
 func (o *GetTransactionDirectdebitsIDReturnsReturnIDReversalsReversalIDOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/direct_debits/list_direct_debits_responses.go
+++ b/pkg/generated/client/direct_debits/list_direct_debits_responses.go
@@ -55,7 +55,7 @@ type ListDirectDebitsOK struct {
 }
 
 func (o *ListDirectDebitsOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/directdebits][%d] listDirectDebitsOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/directdebits][%d] listDirectDebitsOK", 200)
 }
 
 func (o *ListDirectDebitsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/mandates/create_mandate_responses.go
+++ b/pkg/generated/client/mandates/create_mandate_responses.go
@@ -62,7 +62,7 @@ type CreateMandateCreated struct {
 }
 
 func (o *CreateMandateCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/mandates][%d] createMandateCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/mandates][%d] createMandateCreated", 201)
 }
 
 func (o *CreateMandateCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateMandateBadRequest struct {
 }
 
 func (o *CreateMandateBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/mandates][%d] createMandateBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/mandates][%d] createMandateBadRequest", 400)
 }
 
 func (o *CreateMandateBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/mandates/create_mandate_return_responses.go
+++ b/pkg/generated/client/mandates/create_mandate_return_responses.go
@@ -62,7 +62,7 @@ type CreateMandateReturnCreated struct {
 }
 
 func (o *CreateMandateReturnCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/mandates/{id}/returns][%d] createMandateReturnCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/mandates/{id}/returns][%d] createMandateReturnCreated", 201)
 }
 
 func (o *CreateMandateReturnCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateMandateReturnBadRequest struct {
 }
 
 func (o *CreateMandateReturnBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/mandates/{id}/returns][%d] createMandateReturnBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/mandates/{id}/returns][%d] createMandateReturnBadRequest", 400)
 }
 
 func (o *CreateMandateReturnBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/mandates/create_mandate_return_submission_responses.go
+++ b/pkg/generated/client/mandates/create_mandate_return_submission_responses.go
@@ -62,7 +62,7 @@ type CreateMandateReturnSubmissionCreated struct {
 }
 
 func (o *CreateMandateReturnSubmissionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/mandates/{id}/returns/{returnId}/submissions][%d] createMandateReturnSubmissionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/mandates/{id}/returns/{returnId}/submissions][%d] createMandateReturnSubmissionCreated", 201)
 }
 
 func (o *CreateMandateReturnSubmissionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateMandateReturnSubmissionBadRequest struct {
 }
 
 func (o *CreateMandateReturnSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/mandates/{id}/returns/{returnId}/submissions][%d] createMandateReturnSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/mandates/{id}/returns/{returnId}/submissions][%d] createMandateReturnSubmissionBadRequest", 400)
 }
 
 func (o *CreateMandateReturnSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/mandates/create_mandate_submission_responses.go
+++ b/pkg/generated/client/mandates/create_mandate_submission_responses.go
@@ -62,7 +62,7 @@ type CreateMandateSubmissionCreated struct {
 }
 
 func (o *CreateMandateSubmissionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/mandates/{id}/submissions][%d] createMandateSubmissionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/mandates/{id}/submissions][%d] createMandateSubmissionCreated", 201)
 }
 
 func (o *CreateMandateSubmissionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreateMandateSubmissionBadRequest struct {
 }
 
 func (o *CreateMandateSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/mandates/{id}/submissions][%d] createMandateSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/mandates/{id}/submissions][%d] createMandateSubmissionBadRequest", 400)
 }
 
 func (o *CreateMandateSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/mandates/get_mandate_admission_responses.go
+++ b/pkg/generated/client/mandates/get_mandate_admission_responses.go
@@ -55,7 +55,7 @@ type GetMandateAdmissionOK struct {
 }
 
 func (o *GetMandateAdmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/mandates/{id}/admissions/{admissionId}][%d] getMandateAdmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/mandates/{id}/admissions/{admissionId}][%d] getMandateAdmissionOK", 200)
 }
 
 func (o *GetMandateAdmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/mandates/get_mandate_responses.go
+++ b/pkg/generated/client/mandates/get_mandate_responses.go
@@ -55,7 +55,7 @@ type GetMandateOK struct {
 }
 
 func (o *GetMandateOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/mandates/{id}][%d] getMandateOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/mandates/{id}][%d] getMandateOK", 200)
 }
 
 func (o *GetMandateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/mandates/get_mandate_return_responses.go
+++ b/pkg/generated/client/mandates/get_mandate_return_responses.go
@@ -55,7 +55,7 @@ type GetMandateReturnOK struct {
 }
 
 func (o *GetMandateReturnOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/mandates/{id}/returns/{returnId}][%d] getMandateReturnOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/mandates/{id}/returns/{returnId}][%d] getMandateReturnOK", 200)
 }
 
 func (o *GetMandateReturnOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/mandates/get_mandate_return_submission_responses.go
+++ b/pkg/generated/client/mandates/get_mandate_return_submission_responses.go
@@ -55,7 +55,7 @@ type GetMandateReturnSubmissionOK struct {
 }
 
 func (o *GetMandateReturnSubmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/mandates/{id}/returns/{returnId}/submissions/{submissionId}][%d] getMandateReturnSubmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/mandates/{id}/returns/{returnId}/submissions/{submissionId}][%d] getMandateReturnSubmissionOK", 200)
 }
 
 func (o *GetMandateReturnSubmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/mandates/get_mandate_submission_responses.go
+++ b/pkg/generated/client/mandates/get_mandate_submission_responses.go
@@ -62,7 +62,7 @@ type GetMandateSubmissionOK struct {
 }
 
 func (o *GetMandateSubmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/mandates/{id}/submissions/{submissionId}][%d] getMandateSubmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/mandates/{id}/submissions/{submissionId}][%d] getMandateSubmissionOK", 200)
 }
 
 func (o *GetMandateSubmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type GetMandateSubmissionBadRequest struct {
 }
 
 func (o *GetMandateSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[GET /transaction/mandates/{id}/submissions/{submissionId}][%d] getMandateSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[GET /transaction/mandates/{id}/submissions/{submissionId}][%d] getMandateSubmissionBadRequest", 400)
 }
 
 func (o *GetMandateSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/mandates/get_mandates_health_responses.go
+++ b/pkg/generated/client/mandates/get_mandates_health_responses.go
@@ -55,7 +55,7 @@ type GetMandatesHealthOK struct {
 }
 
 func (o *GetMandatesHealthOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/mandates/health][%d] getMandatesHealthOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/mandates/health][%d] getMandatesHealthOK", 200)
 }
 
 func (o *GetMandatesHealthOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/mandates/list_mandates_responses.go
+++ b/pkg/generated/client/mandates/list_mandates_responses.go
@@ -55,7 +55,7 @@ type ListMandatesOK struct {
 }
 
 func (o *ListMandatesOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/mandates][%d] listMandatesOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/mandates][%d] listMandatesOK", 200)
 }
 
 func (o *ListMandatesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/mandates/modify_mandate_responses.go
+++ b/pkg/generated/client/mandates/modify_mandate_responses.go
@@ -62,7 +62,7 @@ type ModifyMandateOK struct {
 }
 
 func (o *ModifyMandateOK) Error() string {
-	return fmt.Sprintf("[PATCH /transaction/mandates/{id}][%d] modifyMandateOK  %+v", 200, o)
+	return fmt.Sprintf("[PATCH /transaction/mandates/{id}][%d] modifyMandateOK", 200)
 }
 
 func (o *ModifyMandateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type ModifyMandateBadRequest struct {
 }
 
 func (o *ModifyMandateBadRequest) Error() string {
-	return fmt.Sprintf("[PATCH /transaction/mandates/{id}][%d] modifyMandateBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[PATCH /transaction/mandates/{id}][%d] modifyMandateBadRequest", 400)
 }
 
 func (o *ModifyMandateBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/oauth2/create_oauth_token_responses.go
+++ b/pkg/generated/client/oauth2/create_oauth_token_responses.go
@@ -62,7 +62,7 @@ type CreateOauthTokenOK struct {
 }
 
 func (o *CreateOauthTokenOK) Error() string {
-	return fmt.Sprintf("[POST /oauth2/token][%d] createOauthTokenOK  %+v", 200, o)
+	return fmt.Sprintf("[POST /oauth2/token][%d] createOauthTokenOK", 200)
 }
 
 func (o *CreateOauthTokenOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -91,7 +91,7 @@ type CreateOauthTokenForbidden struct {
 }
 
 func (o *CreateOauthTokenForbidden) Error() string {
-	return fmt.Sprintf("[POST /oauth2/token][%d] createOauthTokenForbidden ", 403)
+	return fmt.Sprintf("[POST /oauth2/token][%d] createOauthTokenForbidden", 403)
 }
 
 func (o *CreateOauthTokenForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/organisations/create_unit_responses.go
+++ b/pkg/generated/client/organisations/create_unit_responses.go
@@ -55,7 +55,7 @@ type CreateUnitCreated struct {
 }
 
 func (o *CreateUnitCreated) Error() string {
-	return fmt.Sprintf("[POST /organisation/units][%d] createUnitCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /organisation/units][%d] createUnitCreated", 201)
 }
 
 func (o *CreateUnitCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/organisations/get_unit_responses.go
+++ b/pkg/generated/client/organisations/get_unit_responses.go
@@ -55,7 +55,7 @@ type GetUnitOK struct {
 }
 
 func (o *GetUnitOK) Error() string {
-	return fmt.Sprintf("[GET /organisation/units/{id}][%d] getUnitOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /organisation/units/{id}][%d] getUnitOK", 200)
 }
 
 func (o *GetUnitOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/organisations/get_units_health_responses.go
+++ b/pkg/generated/client/organisations/get_units_health_responses.go
@@ -55,7 +55,7 @@ type GetUnitsHealthOK struct {
 }
 
 func (o *GetUnitsHealthOK) Error() string {
-	return fmt.Sprintf("[GET /organisation/units/health][%d] getUnitsHealthOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /organisation/units/health][%d] getUnitsHealthOK", 200)
 }
 
 func (o *GetUnitsHealthOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/organisations/list_units_responses.go
+++ b/pkg/generated/client/organisations/list_units_responses.go
@@ -55,7 +55,7 @@ type ListUnitsOK struct {
 }
 
 func (o *ListUnitsOK) Error() string {
-	return fmt.Sprintf("[GET /organisation/units][%d] listUnitsOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /organisation/units][%d] listUnitsOK", 200)
 }
 
 func (o *ListUnitsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/organisations/modify_unit_responses.go
+++ b/pkg/generated/client/organisations/modify_unit_responses.go
@@ -55,7 +55,7 @@ type ModifyUnitOK struct {
 }
 
 func (o *ModifyUnitOK) Error() string {
-	return fmt.Sprintf("[PATCH /organisation/units/{id}][%d] modifyUnitOK  %+v", 200, o)
+	return fmt.Sprintf("[PATCH /organisation/units/{id}][%d] modifyUnitOK", 200)
 }
 
 func (o *ModifyUnitOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_advice_responses.go
+++ b/pkg/generated/client/payments/create_payment_advice_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentAdviceCreated struct {
 }
 
 func (o *CreatePaymentAdviceCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/advices][%d] createPaymentAdviceCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/advices][%d] createPaymentAdviceCreated", 201)
 }
 
 func (o *CreatePaymentAdviceCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentAdviceBadRequest struct {
 }
 
 func (o *CreatePaymentAdviceBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/advices][%d] createPaymentAdviceBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/advices][%d] createPaymentAdviceBadRequest", 400)
 }
 
 func (o *CreatePaymentAdviceBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_advice_submission_responses.go
+++ b/pkg/generated/client/payments/create_payment_advice_submission_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentAdviceSubmissionCreated struct {
 }
 
 func (o *CreatePaymentAdviceSubmissionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/advices/{adviceId}/submissions][%d] createPaymentAdviceSubmissionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/advices/{adviceId}/submissions][%d] createPaymentAdviceSubmissionCreated", 201)
 }
 
 func (o *CreatePaymentAdviceSubmissionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentAdviceSubmissionBadRequest struct {
 }
 
 func (o *CreatePaymentAdviceSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/advices/{adviceId}/submissions][%d] createPaymentAdviceSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/advices/{adviceId}/submissions][%d] createPaymentAdviceSubmissionBadRequest", 400)
 }
 
 func (o *CreatePaymentAdviceSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_recall_decision_responses.go
+++ b/pkg/generated/client/payments/create_payment_recall_decision_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentRecallDecisionCreated struct {
 }
 
 func (o *CreatePaymentRecallDecisionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls/{recallId}/decisions][%d] createPaymentRecallDecisionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls/{recallId}/decisions][%d] createPaymentRecallDecisionCreated", 201)
 }
 
 func (o *CreatePaymentRecallDecisionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentRecallDecisionBadRequest struct {
 }
 
 func (o *CreatePaymentRecallDecisionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls/{recallId}/decisions][%d] createPaymentRecallDecisionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls/{recallId}/decisions][%d] createPaymentRecallDecisionBadRequest", 400)
 }
 
 func (o *CreatePaymentRecallDecisionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_recall_decision_submission_responses.go
+++ b/pkg/generated/client/payments/create_payment_recall_decision_submission_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentRecallDecisionSubmissionCreated struct {
 }
 
 func (o *CreatePaymentRecallDecisionSubmissionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls/{recallId}/decisions/{decisionId}/submissions][%d] createPaymentRecallDecisionSubmissionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls/{recallId}/decisions/{decisionId}/submissions][%d] createPaymentRecallDecisionSubmissionCreated", 201)
 }
 
 func (o *CreatePaymentRecallDecisionSubmissionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentRecallDecisionSubmissionBadRequest struct {
 }
 
 func (o *CreatePaymentRecallDecisionSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls/{recallId}/decisions/{decisionId}/submissions][%d] createPaymentRecallDecisionSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls/{recallId}/decisions/{decisionId}/submissions][%d] createPaymentRecallDecisionSubmissionBadRequest", 400)
 }
 
 func (o *CreatePaymentRecallDecisionSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_recall_responses.go
+++ b/pkg/generated/client/payments/create_payment_recall_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentRecallCreated struct {
 }
 
 func (o *CreatePaymentRecallCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls][%d] createPaymentRecallCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls][%d] createPaymentRecallCreated", 201)
 }
 
 func (o *CreatePaymentRecallCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentRecallBadRequest struct {
 }
 
 func (o *CreatePaymentRecallBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls][%d] createPaymentRecallBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls][%d] createPaymentRecallBadRequest", 400)
 }
 
 func (o *CreatePaymentRecallBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_recall_submission_responses.go
+++ b/pkg/generated/client/payments/create_payment_recall_submission_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentRecallSubmissionCreated struct {
 }
 
 func (o *CreatePaymentRecallSubmissionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls/{recallId}/submissions][%d] createPaymentRecallSubmissionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls/{recallId}/submissions][%d] createPaymentRecallSubmissionCreated", 201)
 }
 
 func (o *CreatePaymentRecallSubmissionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentRecallSubmissionBadRequest struct {
 }
 
 func (o *CreatePaymentRecallSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls/{recallId}/submissions][%d] createPaymentRecallSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/recalls/{recallId}/submissions][%d] createPaymentRecallSubmissionBadRequest", 400)
 }
 
 func (o *CreatePaymentRecallSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_responses.go
+++ b/pkg/generated/client/payments/create_payment_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentCreated struct {
 }
 
 func (o *CreatePaymentCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments][%d] createPaymentCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments][%d] createPaymentCreated", 201)
 }
 
 func (o *CreatePaymentCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentBadRequest struct {
 }
 
 func (o *CreatePaymentBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments][%d] createPaymentBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments][%d] createPaymentBadRequest", 400)
 }
 
 func (o *CreatePaymentBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_return_responses.go
+++ b/pkg/generated/client/payments/create_payment_return_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentReturnCreated struct {
 }
 
 func (o *CreatePaymentReturnCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/returns][%d] createPaymentReturnCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/returns][%d] createPaymentReturnCreated", 201)
 }
 
 func (o *CreatePaymentReturnCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentReturnBadRequest struct {
 }
 
 func (o *CreatePaymentReturnBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/returns][%d] createPaymentReturnBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/returns][%d] createPaymentReturnBadRequest", 400)
 }
 
 func (o *CreatePaymentReturnBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_return_reversal_responses.go
+++ b/pkg/generated/client/payments/create_payment_return_reversal_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentReturnReversalCreated struct {
 }
 
 func (o *CreatePaymentReturnReversalCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/returns/{returnId}/reversals][%d] createPaymentReturnReversalCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/returns/{returnId}/reversals][%d] createPaymentReturnReversalCreated", 201)
 }
 
 func (o *CreatePaymentReturnReversalCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentReturnReversalBadRequest struct {
 }
 
 func (o *CreatePaymentReturnReversalBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/returns/{returnId}/reversals][%d] createPaymentReturnReversalBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/returns/{returnId}/reversals][%d] createPaymentReturnReversalBadRequest", 400)
 }
 
 func (o *CreatePaymentReturnReversalBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_return_submission_responses.go
+++ b/pkg/generated/client/payments/create_payment_return_submission_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentReturnSubmissionCreated struct {
 }
 
 func (o *CreatePaymentReturnSubmissionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/returns/{returnId}/submissions][%d] createPaymentReturnSubmissionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/returns/{returnId}/submissions][%d] createPaymentReturnSubmissionCreated", 201)
 }
 
 func (o *CreatePaymentReturnSubmissionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentReturnSubmissionBadRequest struct {
 }
 
 func (o *CreatePaymentReturnSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/returns/{returnId}/submissions][%d] createPaymentReturnSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/returns/{returnId}/submissions][%d] createPaymentReturnSubmissionBadRequest", 400)
 }
 
 func (o *CreatePaymentReturnSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_reversal_responses.go
+++ b/pkg/generated/client/payments/create_payment_reversal_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentReversalCreated struct {
 }
 
 func (o *CreatePaymentReversalCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/reversals][%d] createPaymentReversalCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/reversals][%d] createPaymentReversalCreated", 201)
 }
 
 func (o *CreatePaymentReversalCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentReversalBadRequest struct {
 }
 
 func (o *CreatePaymentReversalBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/reversals][%d] createPaymentReversalBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/reversals][%d] createPaymentReversalBadRequest", 400)
 }
 
 func (o *CreatePaymentReversalBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_reversal_submission_responses.go
+++ b/pkg/generated/client/payments/create_payment_reversal_submission_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentReversalSubmissionCreated struct {
 }
 
 func (o *CreatePaymentReversalSubmissionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/reversals/{reversalId}/submissions][%d] createPaymentReversalSubmissionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/reversals/{reversalId}/submissions][%d] createPaymentReversalSubmissionCreated", 201)
 }
 
 func (o *CreatePaymentReversalSubmissionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentReversalSubmissionBadRequest struct {
 }
 
 func (o *CreatePaymentReversalSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/reversals/{reversalId}/submissions][%d] createPaymentReversalSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/reversals/{reversalId}/submissions][%d] createPaymentReversalSubmissionBadRequest", 400)
 }
 
 func (o *CreatePaymentReversalSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/create_payment_submission_responses.go
+++ b/pkg/generated/client/payments/create_payment_submission_responses.go
@@ -62,7 +62,7 @@ type CreatePaymentSubmissionCreated struct {
 }
 
 func (o *CreatePaymentSubmissionCreated) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/submissions][%d] createPaymentSubmissionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/submissions][%d] createPaymentSubmissionCreated", 201)
 }
 
 func (o *CreatePaymentSubmissionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -96,7 +96,7 @@ type CreatePaymentSubmissionBadRequest struct {
 }
 
 func (o *CreatePaymentSubmissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /transaction/payments/{id}/submissions][%d] createPaymentSubmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[POST /transaction/payments/{id}/submissions][%d] createPaymentSubmissionBadRequest", 400)
 }
 
 func (o *CreatePaymentSubmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_admissions_responses.go
+++ b/pkg/generated/client/payments/get_payment_admissions_responses.go
@@ -55,7 +55,7 @@ type GetPaymentAdmissionsOK struct {
 }
 
 func (o *GetPaymentAdmissionsOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/admissions/{admissionId}][%d] getPaymentAdmissionsOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/admissions/{admissionId}][%d] getPaymentAdmissionsOK", 200)
 }
 
 func (o *GetPaymentAdmissionsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_advice_submission_responses.go
+++ b/pkg/generated/client/payments/get_payment_advice_submission_responses.go
@@ -55,7 +55,7 @@ type GetPaymentAdviceSubmissionOK struct {
 }
 
 func (o *GetPaymentAdviceSubmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/advices/{adviceId}/submissions/{submissionId}][%d] getPaymentAdviceSubmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/advices/{adviceId}/submissions/{submissionId}][%d] getPaymentAdviceSubmissionOK", 200)
 }
 
 func (o *GetPaymentAdviceSubmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_recall_admission_responses.go
+++ b/pkg/generated/client/payments/get_payment_recall_admission_responses.go
@@ -55,7 +55,7 @@ type GetPaymentRecallAdmissionOK struct {
 }
 
 func (o *GetPaymentRecallAdmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/admissions/{admissionId}][%d] getPaymentRecallAdmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/admissions/{admissionId}][%d] getPaymentRecallAdmissionOK", 200)
 }
 
 func (o *GetPaymentRecallAdmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_recall_decision_admission_responses.go
+++ b/pkg/generated/client/payments/get_payment_recall_decision_admission_responses.go
@@ -55,7 +55,7 @@ type GetPaymentRecallDecisionAdmissionOK struct {
 }
 
 func (o *GetPaymentRecallDecisionAdmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/decisions/{decisionId}/admissions/{admissionId}][%d] getPaymentRecallDecisionAdmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/decisions/{decisionId}/admissions/{admissionId}][%d] getPaymentRecallDecisionAdmissionOK", 200)
 }
 
 func (o *GetPaymentRecallDecisionAdmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_recall_decision_responses.go
+++ b/pkg/generated/client/payments/get_payment_recall_decision_responses.go
@@ -55,7 +55,7 @@ type GetPaymentRecallDecisionOK struct {
 }
 
 func (o *GetPaymentRecallDecisionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/decisions/{decisionId}][%d] getPaymentRecallDecisionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/decisions/{decisionId}][%d] getPaymentRecallDecisionOK", 200)
 }
 
 func (o *GetPaymentRecallDecisionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_recall_decision_submission_responses.go
+++ b/pkg/generated/client/payments/get_payment_recall_decision_submission_responses.go
@@ -55,7 +55,7 @@ type GetPaymentRecallDecisionSubmissionOK struct {
 }
 
 func (o *GetPaymentRecallDecisionSubmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/decisions/{decisionId}/submissions/{submissionId}][%d] getPaymentRecallDecisionSubmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/decisions/{decisionId}/submissions/{submissionId}][%d] getPaymentRecallDecisionSubmissionOK", 200)
 }
 
 func (o *GetPaymentRecallDecisionSubmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_recall_responses.go
+++ b/pkg/generated/client/payments/get_payment_recall_responses.go
@@ -55,7 +55,7 @@ type GetPaymentRecallOK struct {
 }
 
 func (o *GetPaymentRecallOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}][%d] getPaymentRecallOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}][%d] getPaymentRecallOK", 200)
 }
 
 func (o *GetPaymentRecallOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_recall_reversal_admission_responses.go
+++ b/pkg/generated/client/payments/get_payment_recall_reversal_admission_responses.go
@@ -55,7 +55,7 @@ type GetPaymentRecallReversalAdmissionOK struct {
 }
 
 func (o *GetPaymentRecallReversalAdmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/reversals/{reversalId}/admissions/{admissionId}][%d] getPaymentRecallReversalAdmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/reversals/{reversalId}/admissions/{admissionId}][%d] getPaymentRecallReversalAdmissionOK", 200)
 }
 
 func (o *GetPaymentRecallReversalAdmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_recall_reversal_responses.go
+++ b/pkg/generated/client/payments/get_payment_recall_reversal_responses.go
@@ -55,7 +55,7 @@ type GetPaymentRecallReversalOK struct {
 }
 
 func (o *GetPaymentRecallReversalOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/reversals/{reversalId}][%d] getPaymentRecallReversalOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/reversals/{reversalId}][%d] getPaymentRecallReversalOK", 200)
 }
 
 func (o *GetPaymentRecallReversalOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_recall_submission_responses.go
+++ b/pkg/generated/client/payments/get_payment_recall_submission_responses.go
@@ -55,7 +55,7 @@ type GetPaymentRecallSubmissionOK struct {
 }
 
 func (o *GetPaymentRecallSubmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/submissions/{submissionId}][%d] getPaymentRecallSubmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/recalls/{recallId}/submissions/{submissionId}][%d] getPaymentRecallSubmissionOK", 200)
 }
 
 func (o *GetPaymentRecallSubmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_responses.go
+++ b/pkg/generated/client/payments/get_payment_responses.go
@@ -55,7 +55,7 @@ type GetPaymentOK struct {
 }
 
 func (o *GetPaymentOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}][%d] getPaymentOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}][%d] getPaymentOK", 200)
 }
 
 func (o *GetPaymentOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_return_admission_responses.go
+++ b/pkg/generated/client/payments/get_payment_return_admission_responses.go
@@ -55,7 +55,7 @@ type GetPaymentReturnAdmissionOK struct {
 }
 
 func (o *GetPaymentReturnAdmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/returns/{returnId}/admissions/{admissionId}][%d] getPaymentReturnAdmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/returns/{returnId}/admissions/{admissionId}][%d] getPaymentReturnAdmissionOK", 200)
 }
 
 func (o *GetPaymentReturnAdmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_return_responses.go
+++ b/pkg/generated/client/payments/get_payment_return_responses.go
@@ -55,7 +55,7 @@ type GetPaymentReturnOK struct {
 }
 
 func (o *GetPaymentReturnOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/returns/{returnId}][%d] getPaymentReturnOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/returns/{returnId}][%d] getPaymentReturnOK", 200)
 }
 
 func (o *GetPaymentReturnOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_return_reversal_admission_responses.go
+++ b/pkg/generated/client/payments/get_payment_return_reversal_admission_responses.go
@@ -55,7 +55,7 @@ type GetPaymentReturnReversalAdmissionOK struct {
 }
 
 func (o *GetPaymentReturnReversalAdmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/returns/{returnId}/reversals/{reversalId}/admissions/{admissionId}][%d] getPaymentReturnReversalAdmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/returns/{returnId}/reversals/{reversalId}/admissions/{admissionId}][%d] getPaymentReturnReversalAdmissionOK", 200)
 }
 
 func (o *GetPaymentReturnReversalAdmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_return_reversal_responses.go
+++ b/pkg/generated/client/payments/get_payment_return_reversal_responses.go
@@ -55,7 +55,7 @@ type GetPaymentReturnReversalOK struct {
 }
 
 func (o *GetPaymentReturnReversalOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/returns/{returnId}/reversals/{reversalId}][%d] getPaymentReturnReversalOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/returns/{returnId}/reversals/{reversalId}][%d] getPaymentReturnReversalOK", 200)
 }
 
 func (o *GetPaymentReturnReversalOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_return_submission_responses.go
+++ b/pkg/generated/client/payments/get_payment_return_submission_responses.go
@@ -55,7 +55,7 @@ type GetPaymentReturnSubmissionOK struct {
 }
 
 func (o *GetPaymentReturnSubmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/returns/{returnId}/submissions/{submissionId}][%d] getPaymentReturnSubmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/returns/{returnId}/submissions/{submissionId}][%d] getPaymentReturnSubmissionOK", 200)
 }
 
 func (o *GetPaymentReturnSubmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_reversal_admission_responses.go
+++ b/pkg/generated/client/payments/get_payment_reversal_admission_responses.go
@@ -55,7 +55,7 @@ type GetPaymentReversalAdmissionOK struct {
 }
 
 func (o *GetPaymentReversalAdmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/reversals/{reversalId}/admissions/{admissionId}][%d] getPaymentReversalAdmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/reversals/{reversalId}/admissions/{admissionId}][%d] getPaymentReversalAdmissionOK", 200)
 }
 
 func (o *GetPaymentReversalAdmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_reversal_responses.go
+++ b/pkg/generated/client/payments/get_payment_reversal_responses.go
@@ -55,7 +55,7 @@ type GetPaymentReversalOK struct {
 }
 
 func (o *GetPaymentReversalOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/reversals/{reversalId}][%d] getPaymentReversalOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/reversals/{reversalId}][%d] getPaymentReversalOK", 200)
 }
 
 func (o *GetPaymentReversalOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_reversal_submission_responses.go
+++ b/pkg/generated/client/payments/get_payment_reversal_submission_responses.go
@@ -55,7 +55,7 @@ type GetPaymentReversalSubmissionOK struct {
 }
 
 func (o *GetPaymentReversalSubmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/reversals/{reversalId}/submissions/{submissionId}][%d] getPaymentReversalSubmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/reversals/{reversalId}/submissions/{submissionId}][%d] getPaymentReversalSubmissionOK", 200)
 }
 
 func (o *GetPaymentReversalSubmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payment_submission_responses.go
+++ b/pkg/generated/client/payments/get_payment_submission_responses.go
@@ -55,7 +55,7 @@ type GetPaymentSubmissionOK struct {
 }
 
 func (o *GetPaymentSubmissionOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/submissions/{submissionId}][%d] getPaymentSubmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/submissions/{submissionId}][%d] getPaymentSubmissionOK", 200)
 }
 
 func (o *GetPaymentSubmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_payments_health_responses.go
+++ b/pkg/generated/client/payments/get_payments_health_responses.go
@@ -55,7 +55,7 @@ type GetPaymentsHealthOK struct {
 }
 
 func (o *GetPaymentsHealthOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/health][%d] getPaymentsHealthOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/health][%d] getPaymentsHealthOK", 200)
 }
 
 func (o *GetPaymentsHealthOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/get_positions_responses.go
+++ b/pkg/generated/client/payments/get_positions_responses.go
@@ -55,7 +55,7 @@ type GetPositionsOK struct {
 }
 
 func (o *GetPositionsOK) Error() string {
-	return fmt.Sprintf("[GET /organisation/positions][%d] getPositionsOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /organisation/positions][%d] getPositionsOK", 200)
 }
 
 func (o *GetPositionsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/list_payment_advices_responses.go
+++ b/pkg/generated/client/payments/list_payment_advices_responses.go
@@ -55,7 +55,7 @@ type ListPaymentAdvicesOK struct {
 }
 
 func (o *ListPaymentAdvicesOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments/{id}/advices/{adviceId}][%d] listPaymentAdvicesOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments/{id}/advices/{adviceId}][%d] listPaymentAdvicesOK", 200)
 }
 
 func (o *ListPaymentAdvicesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/payments/list_payments_responses.go
+++ b/pkg/generated/client/payments/list_payments_responses.go
@@ -55,7 +55,7 @@ type ListPaymentsOK struct {
 }
 
 func (o *ListPaymentsOK) Error() string {
-	return fmt.Sprintf("[GET /transaction/payments][%d] listPaymentsOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /transaction/payments][%d] listPaymentsOK", 200)
 }
 
 func (o *ListPaymentsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/reports/get_report_admission_responses.go
+++ b/pkg/generated/client/reports/get_report_admission_responses.go
@@ -76,7 +76,7 @@ type GetReportAdmissionOK struct {
 }
 
 func (o *GetReportAdmissionOK) Error() string {
-	return fmt.Sprintf("[GET /notification/reports/{id}/admissions/{admissionId}][%d] getReportAdmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /notification/reports/{id}/admissions/{admissionId}][%d] getReportAdmissionOK", 200)
 }
 
 func (o *GetReportAdmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -110,7 +110,7 @@ type GetReportAdmissionBadRequest struct {
 }
 
 func (o *GetReportAdmissionBadRequest) Error() string {
-	return fmt.Sprintf("[GET /notification/reports/{id}/admissions/{admissionId}][%d] getReportAdmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[GET /notification/reports/{id}/admissions/{admissionId}][%d] getReportAdmissionBadRequest", 400)
 }
 
 func (o *GetReportAdmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -144,7 +144,7 @@ type GetReportAdmissionForbidden struct {
 }
 
 func (o *GetReportAdmissionForbidden) Error() string {
-	return fmt.Sprintf("[GET /notification/reports/{id}/admissions/{admissionId}][%d] getReportAdmissionForbidden  %+v", 403, o)
+	return fmt.Sprintf("[GET /notification/reports/{id}/admissions/{admissionId}][%d] getReportAdmissionForbidden", 403)
 }
 
 func (o *GetReportAdmissionForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -178,7 +178,7 @@ type GetReportAdmissionNotFound struct {
 }
 
 func (o *GetReportAdmissionNotFound) Error() string {
-	return fmt.Sprintf("[GET /notification/reports/{id}/admissions/{admissionId}][%d] getReportAdmissionNotFound  %+v", 404, o)
+	return fmt.Sprintf("[GET /notification/reports/{id}/admissions/{admissionId}][%d] getReportAdmissionNotFound", 404)
 }
 
 func (o *GetReportAdmissionNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/reports/get_report_responses.go
+++ b/pkg/generated/client/reports/get_report_responses.go
@@ -83,7 +83,7 @@ type GetReportOK struct {
 }
 
 func (o *GetReportOK) Error() string {
-	return fmt.Sprintf("[GET /notification/reports/{id}][%d] getReportOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /notification/reports/{id}][%d] getReportOK", 200)
 }
 
 func (o *GetReportOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -117,7 +117,7 @@ type GetReportBadRequest struct {
 }
 
 func (o *GetReportBadRequest) Error() string {
-	return fmt.Sprintf("[GET /notification/reports/{id}][%d] getReportBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[GET /notification/reports/{id}][%d] getReportBadRequest", 400)
 }
 
 func (o *GetReportBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -151,7 +151,7 @@ type GetReportForbidden struct {
 }
 
 func (o *GetReportForbidden) Error() string {
-	return fmt.Sprintf("[GET /notification/reports/{id}][%d] getReportForbidden  %+v", 403, o)
+	return fmt.Sprintf("[GET /notification/reports/{id}][%d] getReportForbidden", 403)
 }
 
 func (o *GetReportForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -185,7 +185,7 @@ type GetReportNotFound struct {
 }
 
 func (o *GetReportNotFound) Error() string {
-	return fmt.Sprintf("[GET /notification/reports/{id}][%d] getReportNotFound  %+v", 404, o)
+	return fmt.Sprintf("[GET /notification/reports/{id}][%d] getReportNotFound", 404)
 }
 
 func (o *GetReportNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -219,7 +219,7 @@ type GetReportNotAcceptable struct {
 }
 
 func (o *GetReportNotAcceptable) Error() string {
-	return fmt.Sprintf("[GET /notification/reports/{id}][%d] getReportNotAcceptable  %+v", 406, o)
+	return fmt.Sprintf("[GET /notification/reports/{id}][%d] getReportNotAcceptable", 406)
 }
 
 func (o *GetReportNotAcceptable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/reports/list_reports_responses.go
+++ b/pkg/generated/client/reports/list_reports_responses.go
@@ -69,7 +69,7 @@ type ListReportsOK struct {
 }
 
 func (o *ListReportsOK) Error() string {
-	return fmt.Sprintf("[GET /notification/reports][%d] listReportsOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /notification/reports][%d] listReportsOK", 200)
 }
 
 func (o *ListReportsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -103,7 +103,7 @@ type ListReportsBadRequest struct {
 }
 
 func (o *ListReportsBadRequest) Error() string {
-	return fmt.Sprintf("[GET /notification/reports][%d] listReportsBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[GET /notification/reports][%d] listReportsBadRequest", 400)
 }
 
 func (o *ListReportsBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -137,7 +137,7 @@ type ListReportsForbidden struct {
 }
 
 func (o *ListReportsForbidden) Error() string {
-	return fmt.Sprintf("[GET /notification/reports][%d] listReportsForbidden  %+v", 403, o)
+	return fmt.Sprintf("[GET /notification/reports][%d] listReportsForbidden", 403)
 }
 
 func (o *ListReportsForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/roles/create_roles_responses.go
+++ b/pkg/generated/client/roles/create_roles_responses.go
@@ -55,7 +55,7 @@ type CreateRolesCreated struct {
 }
 
 func (o *CreateRolesCreated) Error() string {
-	return fmt.Sprintf("[POST /security/roles][%d] createRolesCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /security/roles][%d] createRolesCreated", 201)
 }
 
 func (o *CreateRolesCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/roles/delete_role_responses.go
+++ b/pkg/generated/client/roles/delete_role_responses.go
@@ -47,7 +47,7 @@ type DeleteRoleNoContent struct {
 }
 
 func (o *DeleteRoleNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /security/roles/{role_id}][%d] deleteRoleNoContent ", 204)
+	return fmt.Sprintf("[DELETE /security/roles/{role_id}][%d] deleteRoleNoContent", 204)
 }
 
 func (o *DeleteRoleNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/roles/get_role_responses.go
+++ b/pkg/generated/client/roles/get_role_responses.go
@@ -55,7 +55,7 @@ type GetRoleOK struct {
 }
 
 func (o *GetRoleOK) Error() string {
-	return fmt.Sprintf("[GET /security/roles/{role_id}][%d] getRoleOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /security/roles/{role_id}][%d] getRoleOK", 200)
 }
 
 func (o *GetRoleOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/roles/list_roles_responses.go
+++ b/pkg/generated/client/roles/list_roles_responses.go
@@ -55,7 +55,7 @@ type ListRolesOK struct {
 }
 
 func (o *ListRolesOK) Error() string {
-	return fmt.Sprintf("[GET /security/roles][%d] listRolesOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /security/roles][%d] listRolesOK", 200)
 }
 
 func (o *ListRolesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/scheme_messages/get_scheme_message_admission_responses.go
+++ b/pkg/generated/client/scheme_messages/get_scheme_message_admission_responses.go
@@ -76,7 +76,7 @@ type GetSchemeMessageAdmissionOK struct {
 }
 
 func (o *GetSchemeMessageAdmissionOK) Error() string {
-	return fmt.Sprintf("[GET /notification/schememessages/{id}/admissions/{admissionId}][%d] getSchemeMessageAdmissionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /notification/schememessages/{id}/admissions/{admissionId}][%d] getSchemeMessageAdmissionOK", 200)
 }
 
 func (o *GetSchemeMessageAdmissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -110,7 +110,7 @@ type GetSchemeMessageAdmissionBadRequest struct {
 }
 
 func (o *GetSchemeMessageAdmissionBadRequest) Error() string {
-	return fmt.Sprintf("[GET /notification/schememessages/{id}/admissions/{admissionId}][%d] getSchemeMessageAdmissionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[GET /notification/schememessages/{id}/admissions/{admissionId}][%d] getSchemeMessageAdmissionBadRequest", 400)
 }
 
 func (o *GetSchemeMessageAdmissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -144,7 +144,7 @@ type GetSchemeMessageAdmissionForbidden struct {
 }
 
 func (o *GetSchemeMessageAdmissionForbidden) Error() string {
-	return fmt.Sprintf("[GET /notification/schememessages/{id}/admissions/{admissionId}][%d] getSchemeMessageAdmissionForbidden  %+v", 403, o)
+	return fmt.Sprintf("[GET /notification/schememessages/{id}/admissions/{admissionId}][%d] getSchemeMessageAdmissionForbidden", 403)
 }
 
 func (o *GetSchemeMessageAdmissionForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -178,7 +178,7 @@ type GetSchemeMessageAdmissionNotFound struct {
 }
 
 func (o *GetSchemeMessageAdmissionNotFound) Error() string {
-	return fmt.Sprintf("[GET /notification/schememessages/{id}/admissions/{admissionId}][%d] getSchemeMessageAdmissionNotFound  %+v", 404, o)
+	return fmt.Sprintf("[GET /notification/schememessages/{id}/admissions/{admissionId}][%d] getSchemeMessageAdmissionNotFound", 404)
 }
 
 func (o *GetSchemeMessageAdmissionNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/scheme_messages/get_scheme_message_responses.go
+++ b/pkg/generated/client/scheme_messages/get_scheme_message_responses.go
@@ -76,7 +76,7 @@ type GetSchemeMessageOK struct {
 }
 
 func (o *GetSchemeMessageOK) Error() string {
-	return fmt.Sprintf("[GET /notification/schememessages/{id}][%d] getSchemeMessageOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /notification/schememessages/{id}][%d] getSchemeMessageOK", 200)
 }
 
 func (o *GetSchemeMessageOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -110,7 +110,7 @@ type GetSchemeMessageBadRequest struct {
 }
 
 func (o *GetSchemeMessageBadRequest) Error() string {
-	return fmt.Sprintf("[GET /notification/schememessages/{id}][%d] getSchemeMessageBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[GET /notification/schememessages/{id}][%d] getSchemeMessageBadRequest", 400)
 }
 
 func (o *GetSchemeMessageBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -144,7 +144,7 @@ type GetSchemeMessageForbidden struct {
 }
 
 func (o *GetSchemeMessageForbidden) Error() string {
-	return fmt.Sprintf("[GET /notification/schememessages/{id}][%d] getSchemeMessageForbidden  %+v", 403, o)
+	return fmt.Sprintf("[GET /notification/schememessages/{id}][%d] getSchemeMessageForbidden", 403)
 }
 
 func (o *GetSchemeMessageForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -178,7 +178,7 @@ type GetSchemeMessageNotFound struct {
 }
 
 func (o *GetSchemeMessageNotFound) Error() string {
-	return fmt.Sprintf("[GET /notification/schememessages/{id}][%d] getSchemeMessageNotFound  %+v", 404, o)
+	return fmt.Sprintf("[GET /notification/schememessages/{id}][%d] getSchemeMessageNotFound", 404)
 }
 
 func (o *GetSchemeMessageNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/scheme_messages/list_scheme_messages_responses.go
+++ b/pkg/generated/client/scheme_messages/list_scheme_messages_responses.go
@@ -69,7 +69,7 @@ type ListSchemeMessagesOK struct {
 }
 
 func (o *ListSchemeMessagesOK) Error() string {
-	return fmt.Sprintf("[GET /notification/schememessages][%d] listSchemeMessagesOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /notification/schememessages][%d] listSchemeMessagesOK", 200)
 }
 
 func (o *ListSchemeMessagesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -103,7 +103,7 @@ type ListSchemeMessagesBadRequest struct {
 }
 
 func (o *ListSchemeMessagesBadRequest) Error() string {
-	return fmt.Sprintf("[GET /notification/schememessages][%d] listSchemeMessagesBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[GET /notification/schememessages][%d] listSchemeMessagesBadRequest", 400)
 }
 
 func (o *ListSchemeMessagesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -137,7 +137,7 @@ type ListSchemeMessagesForbidden struct {
 }
 
 func (o *ListSchemeMessagesForbidden) Error() string {
-	return fmt.Sprintf("[GET /notification/schememessages][%d] listSchemeMessagesForbidden  %+v", 403, o)
+	return fmt.Sprintf("[GET /notification/schememessages][%d] listSchemeMessagesForbidden", 403)
 }
 
 func (o *ListSchemeMessagesForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/subscriptions/create_subscription_responses.go
+++ b/pkg/generated/client/subscriptions/create_subscription_responses.go
@@ -55,7 +55,7 @@ type CreateSubscriptionCreated struct {
 }
 
 func (o *CreateSubscriptionCreated) Error() string {
-	return fmt.Sprintf("[POST /notification/subscriptions][%d] createSubscriptionCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /notification/subscriptions][%d] createSubscriptionCreated", 201)
 }
 
 func (o *CreateSubscriptionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/subscriptions/delete_subscription_responses.go
+++ b/pkg/generated/client/subscriptions/delete_subscription_responses.go
@@ -47,7 +47,7 @@ type DeleteSubscriptionNoContent struct {
 }
 
 func (o *DeleteSubscriptionNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /notification/subscriptions/{id}][%d] deleteSubscriptionNoContent ", 204)
+	return fmt.Sprintf("[DELETE /notification/subscriptions/{id}][%d] deleteSubscriptionNoContent", 204)
 }
 
 func (o *DeleteSubscriptionNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/subscriptions/get_subscription_responses.go
+++ b/pkg/generated/client/subscriptions/get_subscription_responses.go
@@ -55,7 +55,7 @@ type GetSubscriptionOK struct {
 }
 
 func (o *GetSubscriptionOK) Error() string {
-	return fmt.Sprintf("[GET /notification/subscriptions/{id}][%d] getSubscriptionOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /notification/subscriptions/{id}][%d] getSubscriptionOK", 200)
 }
 
 func (o *GetSubscriptionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/subscriptions/get_subscriptions_health_responses.go
+++ b/pkg/generated/client/subscriptions/get_subscriptions_health_responses.go
@@ -55,7 +55,7 @@ type GetSubscriptionsHealthOK struct {
 }
 
 func (o *GetSubscriptionsHealthOK) Error() string {
-	return fmt.Sprintf("[GET /notification/subscriptions/health][%d] getSubscriptionsHealthOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /notification/subscriptions/health][%d] getSubscriptionsHealthOK", 200)
 }
 
 func (o *GetSubscriptionsHealthOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/subscriptions/list_subscriptions_responses.go
+++ b/pkg/generated/client/subscriptions/list_subscriptions_responses.go
@@ -55,7 +55,7 @@ type ListSubscriptionsOK struct {
 }
 
 func (o *ListSubscriptionsOK) Error() string {
-	return fmt.Sprintf("[GET /notification/subscriptions][%d] listSubscriptionsOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /notification/subscriptions][%d] listSubscriptionsOK", 200)
 }
 
 func (o *ListSubscriptionsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/subscriptions/modify_subscription_responses.go
+++ b/pkg/generated/client/subscriptions/modify_subscription_responses.go
@@ -83,7 +83,7 @@ type ModifySubscriptionOK struct {
 }
 
 func (o *ModifySubscriptionOK) Error() string {
-	return fmt.Sprintf("[PATCH /notification/subscriptions/{id}][%d] modifySubscriptionOK  %+v", 200, o)
+	return fmt.Sprintf("[PATCH /notification/subscriptions/{id}][%d] modifySubscriptionOK", 200)
 }
 
 func (o *ModifySubscriptionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -117,7 +117,7 @@ type ModifySubscriptionBadRequest struct {
 }
 
 func (o *ModifySubscriptionBadRequest) Error() string {
-	return fmt.Sprintf("[PATCH /notification/subscriptions/{id}][%d] modifySubscriptionBadRequest  %+v", 400, o)
+	return fmt.Sprintf("[PATCH /notification/subscriptions/{id}][%d] modifySubscriptionBadRequest", 400)
 }
 
 func (o *ModifySubscriptionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -151,7 +151,7 @@ type ModifySubscriptionNotFound struct {
 }
 
 func (o *ModifySubscriptionNotFound) Error() string {
-	return fmt.Sprintf("[PATCH /notification/subscriptions/{id}][%d] modifySubscriptionNotFound  %+v", 404, o)
+	return fmt.Sprintf("[PATCH /notification/subscriptions/{id}][%d] modifySubscriptionNotFound", 404)
 }
 
 func (o *ModifySubscriptionNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -185,7 +185,7 @@ type ModifySubscriptionConflict struct {
 }
 
 func (o *ModifySubscriptionConflict) Error() string {
-	return fmt.Sprintf("[PATCH /notification/subscriptions/{id}][%d] modifySubscriptionConflict  %+v", 409, o)
+	return fmt.Sprintf("[PATCH /notification/subscriptions/{id}][%d] modifySubscriptionConflict", 409)
 }
 
 func (o *ModifySubscriptionConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -219,7 +219,7 @@ type ModifySubscriptionInternalServerError struct {
 }
 
 func (o *ModifySubscriptionInternalServerError) Error() string {
-	return fmt.Sprintf("[PATCH /notification/subscriptions/{id}][%d] modifySubscriptionInternalServerError  %+v", 500, o)
+	return fmt.Sprintf("[PATCH /notification/subscriptions/{id}][%d] modifySubscriptionInternalServerError", 500)
 }
 
 func (o *ModifySubscriptionInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/create_user_credentials_responses.go
+++ b/pkg/generated/client/users/create_user_credentials_responses.go
@@ -55,7 +55,7 @@ type CreateUserCredentialsCreated struct {
 }
 
 func (o *CreateUserCredentialsCreated) Error() string {
-	return fmt.Sprintf("[POST /security/users/{user_id}/credentials][%d] createUserCredentialsCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /security/users/{user_id}/credentials][%d] createUserCredentialsCreated", 201)
 }
 
 func (o *CreateUserCredentialsCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/create_user_responses.go
+++ b/pkg/generated/client/users/create_user_responses.go
@@ -55,7 +55,7 @@ type CreateUserCreated struct {
 }
 
 func (o *CreateUserCreated) Error() string {
-	return fmt.Sprintf("[POST /security/users][%d] createUserCreated  %+v", 201, o)
+	return fmt.Sprintf("[POST /security/users][%d] createUserCreated", 201)
 }
 
 func (o *CreateUserCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/create_user_role_responses.go
+++ b/pkg/generated/client/users/create_user_role_responses.go
@@ -47,7 +47,7 @@ type CreateUserRoleCreated struct {
 }
 
 func (o *CreateUserRoleCreated) Error() string {
-	return fmt.Sprintf("[POST /security/users/{user_id}/roles/{role_id}][%d] createUserRoleCreated ", 201)
+	return fmt.Sprintf("[POST /security/users/{user_id}/roles/{role_id}][%d] createUserRoleCreated", 201)
 }
 
 func (o *CreateUserRoleCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/delete_user_credential_responses.go
+++ b/pkg/generated/client/users/delete_user_credential_responses.go
@@ -47,7 +47,7 @@ type DeleteUserCredentialNoContent struct {
 }
 
 func (o *DeleteUserCredentialNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /security/users/{user_id}/credentials/{client_id}][%d] deleteUserCredentialNoContent ", 204)
+	return fmt.Sprintf("[DELETE /security/users/{user_id}/credentials/{client_id}][%d] deleteUserCredentialNoContent", 204)
 }
 
 func (o *DeleteUserCredentialNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/delete_user_responses.go
+++ b/pkg/generated/client/users/delete_user_responses.go
@@ -47,7 +47,7 @@ type DeleteUserNoContent struct {
 }
 
 func (o *DeleteUserNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /security/users/{user_id}][%d] deleteUserNoContent ", 204)
+	return fmt.Sprintf("[DELETE /security/users/{user_id}][%d] deleteUserNoContent", 204)
 }
 
 func (o *DeleteUserNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/delete_user_role_responses.go
+++ b/pkg/generated/client/users/delete_user_role_responses.go
@@ -47,7 +47,7 @@ type DeleteUserRoleNoContent struct {
 }
 
 func (o *DeleteUserRoleNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /security/users/{user_id}/roles/{role_id}][%d] deleteUserRoleNoContent ", 204)
+	return fmt.Sprintf("[DELETE /security/users/{user_id}/roles/{role_id}][%d] deleteUserRoleNoContent", 204)
 }
 
 func (o *DeleteUserRoleNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/get_user_aces_responses.go
+++ b/pkg/generated/client/users/get_user_aces_responses.go
@@ -55,7 +55,7 @@ type GetUserAcesOK struct {
 }
 
 func (o *GetUserAcesOK) Error() string {
-	return fmt.Sprintf("[GET /security/users/{user_id}/aces][%d] getUserAcesOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /security/users/{user_id}/aces][%d] getUserAcesOK", 200)
 }
 
 func (o *GetUserAcesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/get_user_responses.go
+++ b/pkg/generated/client/users/get_user_responses.go
@@ -55,7 +55,7 @@ type GetUserOK struct {
 }
 
 func (o *GetUserOK) Error() string {
-	return fmt.Sprintf("[GET /security/users/{user_id}][%d] getUserOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /security/users/{user_id}][%d] getUserOK", 200)
 }
 
 func (o *GetUserOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/get_users_health_responses.go
+++ b/pkg/generated/client/users/get_users_health_responses.go
@@ -55,7 +55,7 @@ type GetUsersHealthOK struct {
 }
 
 func (o *GetUsersHealthOK) Error() string {
-	return fmt.Sprintf("[GET /security/users/health][%d] getUsersHealthOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /security/users/health][%d] getUsersHealthOK", 200)
 }
 
 func (o *GetUsersHealthOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/list_user_credentials_responses.go
+++ b/pkg/generated/client/users/list_user_credentials_responses.go
@@ -55,7 +55,7 @@ type ListUserCredentialsOK struct {
 }
 
 func (o *ListUserCredentialsOK) Error() string {
-	return fmt.Sprintf("[GET /security/users/{user_id}/credentials][%d] listUserCredentialsOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /security/users/{user_id}/credentials][%d] listUserCredentialsOK", 200)
 }
 
 func (o *ListUserCredentialsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/list_user_roles_responses.go
+++ b/pkg/generated/client/users/list_user_roles_responses.go
@@ -55,7 +55,7 @@ type ListUserRolesOK struct {
 }
 
 func (o *ListUserRolesOK) Error() string {
-	return fmt.Sprintf("[GET /security/users/{user_id}/roles][%d] listUserRolesOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /security/users/{user_id}/roles][%d] listUserRolesOK", 200)
 }
 
 func (o *ListUserRolesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/list_users_responses.go
+++ b/pkg/generated/client/users/list_users_responses.go
@@ -55,7 +55,7 @@ type ListUsersOK struct {
 }
 
 func (o *ListUsersOK) Error() string {
-	return fmt.Sprintf("[GET /security/users][%d] listUsersOK  %+v", 200, o)
+	return fmt.Sprintf("[GET /security/users][%d] listUsersOK", 200)
 }
 
 func (o *ListUsersOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/pkg/generated/client/users/modify_user_responses.go
+++ b/pkg/generated/client/users/modify_user_responses.go
@@ -55,7 +55,7 @@ type ModifyUserOK struct {
 }
 
 func (o *ModifyUserOK) Error() string {
-	return fmt.Sprintf("[PATCH /security/users/{user_id}][%d] modifyUserOK  %+v", 200, o)
+	return fmt.Sprintf("[PATCH /security/users/{user_id}][%d] modifyUserOK", 200)
 }
 
 func (o *ModifyUserOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {

--- a/templates/client/response.gotmpl
+++ b/templates/client/response.gotmpl
@@ -35,7 +35,7 @@ func ({{ .ReceiverName }} *{{ pascalize .Name }}) Code() int {
 
 
 func ({{ .ReceiverName }} *{{ pascalize .Name }}) Error() string {
-	return fmt.Sprintf("[{{ upper .Method }} {{ .Path }}][%d] {{ if .Name }}{{ .Name }} {{ else }}unknown error {{ end }}{{ if .Schema }} %+v{{ end }}", {{ if eq .Code -1 }}{{ .ReceiverName }}._statusCode{{ else }}{{ .Code }}{{ end }}{{ if .Schema }}, o{{ end }})
+	return fmt.Sprintf("[{{ upper .Method }} {{ .Path }}][%d] {{ if .Name }}{{ .Name }}{{ else }}unknown error{{ end }}{{ if .Schema }}{{ end }}", {{ if eq .Code -1 }}{{ .ReceiverName }}._statusCode{{ else }}{{ .Code }}{{ end }})
 }
 
 


### PR DESCRIPTION
When printing with %+v go's Fprintf implementation calls Error()
for types that implement the `.(Error)` interface. This results
in an infinate loop and thus a stack overflow.