### PR TITLE
Make GetStrfmtUUID consistent with GetStrfmtUUIDPtr

### DIFF
--- a/pkg/client/client_defaults.go
+++ b/pkg/client/client_defaults.go
@@ -10,6 +10,16 @@ type ClientDefaults struct {
 	OrganisationId *strfmt.UUID
 }
 
+func (d *ClientDefaults) GetStrfmtUUID(objectName, attributeName string) strfmt.UUID {
+	var a strfmt.UUID
+	if "organisation_id" == attributeName && d.OrganisationId != nil {
+		a = *d.OrganisationId
+	} else if "id" == attributeName {
+		a = strfmt.UUID(uuid.Must(uuid.NewRandom()).String())
+	}
+	return a
+}
+
 func (d *ClientDefaults) GetStrfmtUUIDPtr(objectName, attributeName string) *strfmt.UUID {
 	if "organisation_id" == attributeName {
 		return d.OrganisationId

--- a/pkg/form3/client_defaults.go
+++ b/pkg/form3/client_defaults.go
@@ -9,8 +9,13 @@ type ClientDefaults struct {
 	OrganisationId *strfmt.UUID
 }
 
-func (*ClientDefaults) GetStrfmtUUID(objectName, attributeName string) strfmt.UUID {
+func (d *ClientDefaults) GetStrfmtUUID(objectName, attributeName string) strfmt.UUID {
 	var a strfmt.UUID
+	if "organisation_id" == attributeName && d.OrganisationId != nil {
+		a = *d.OrganisationId
+	} else if "id" == attributeName {
+		a = strfmt.UUID(uuid.Must(uuid.NewRandom()).String())
+	}
 	return a
 }
 


### PR DESCRIPTION
Some resources don't use pointers for their UUID attributes and the
requests end up not having values for `OrganisationId` and `ID`