### PR TITLE
Adds support for map[string]interface{}

### DIFF
--- a/pkg/client/defaults.go
+++ b/pkg/client/defaults.go
@@ -29,4 +29,6 @@ type Defaults interface {
 
 	GetFloat64(objectName, attributeName string) float64
 	GetFloat64Ptr(objectName, attributeName string) *float64
+
+	GetMapStringInterface(objectName, attributeName string) map[string]interface{}
 }

--- a/pkg/client/empty_defaults.go
+++ b/pkg/client/empty_defaults.go
@@ -87,3 +87,7 @@ func (*EmptyDefaults) GetFloat64(objectName, attributeName string) float64 {
 func (*EmptyDefaults) GetFloat64Ptr(objectName, attributeName string) *float64 {
 	return nil
 }
+
+func (*EmptyDefaults) GetMapStringInterface(objectName, attributeName string) map[string]interface{} {
+	return nil
+}

--- a/pkg/form3/client_defaults.go
+++ b/pkg/form3/client_defaults.go
@@ -98,6 +98,10 @@ func (*ClientDefaults) GetFloat64Ptr(objectName, attributeName string) *float64 
 	return nil
 }
 
+func (*ClientDefaults) GetMapStringInterface(objectName, attributeName string) map[string]interface{} {
+	return nil
+}
+
 func NewClientDefaults() *ClientDefaults {
 	return &ClientDefaults{}
 }


### PR DESCRIPTION
In PaymentAPI we will be introducing a dynamic object based on swagger: https://swagger.io/docs/specification/data-models/dictionaries/

This provides support for go map[string]interface{} which is supported in other languages