### PR TITLE
add signature-debug config option

### DIFF
--- a/pkg/form3/auth_request_signing.go
+++ b/pkg/form3/auth_request_signing.go
@@ -50,6 +50,8 @@ func WithUnderlyingRequestSigningTransport(tr http.RoundTripper) RequestSigningO
 	}
 }
 
+// WithDebugMode diverts requests to an endpoint that can help to debug a mismatching request signature between client
+// and server.
 func WithDebugMode(enabled bool) RequestSigningOption {
 	return func(t *RequestSigningTransport) {
 		t.isDebugMode = enabled
@@ -148,6 +150,7 @@ content-length: %d`,
 
 	if t.isDebugMode {
 		req.Header.Set("signature-debug", base64.StdEncoding.EncodeToString([]byte(msgToSign)))
+		req.URL.Path = "/v1/http-signatures/debug"
 	}
 
 	return t.underlyingTransport.RoundTrip(req)


### PR DESCRIPTION
Adds the option to include a signature-debug header for request signing debug mode