### PR TITLE
feat: add `http_azure_private` subscription callback transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ A simple client library with:
 - A fluent API with reduced repetition compared with vanilla swagger-go generated clients
 - All the power and flexibility of Go!
 
+## Contributing
+
+Please include proof of running the full test suite over the Form3 API with the following variables set:
+  * `FORM3_CLIENT_ID`
+  * `FORM3_CLIENT_SECRET`
+  * `FORM3_ORGANISATION_ID`
+  * `FORM3_HOST`
+  * `FORM3_PRIVATE_KEY`
+  * `FORM3_PUBLIC_KEY_ID`
+
+In case of external contributions, it is the responsibility of the reviewer to run those tests.
+
 ## Getting started
 
 For interactive usage we recommend using [gore](https://github.com/motemen/gore).

--- a/pkg/form3/auth_token_test.go
+++ b/pkg/form3/auth_token_test.go
@@ -11,9 +11,7 @@ import (
 )
 
 func TestTokenAuth(t *testing.T) {
-	if os.Getenv("FORM3_CLIENT_ID") == "" || os.Getenv("FORM3_CLIENT_SECRET") == "" {
-		t.Skip("WARN: FORM3_CLIENT_ID or FORM3_CLIENT_SECRET not set, skipping test")
-	}
+	skipWhenCredentialsMissing(t)
 
 	u, err := uuid.Parse(os.Getenv("FORM3_CLIENT_ID"))
 	require.NoError(t, err)

--- a/pkg/form3/helpers_test.go
+++ b/pkg/form3/helpers_test.go
@@ -1,0 +1,12 @@
+package form3_test
+
+import (
+	"os"
+	"testing"
+)
+
+func skipWhenCredentialsMissing(t *testing.T) {
+	if os.Getenv("FORM3_CLIENT_ID") == "" || os.Getenv("FORM3_CLIENT_SECRET") == "" {
+		t.Skip("WARN: FORM3_CLIENT_ID or FORM3_CLIENT_SECRET not set, skipping test")
+	}
+}

--- a/pkg/form3/payments_test.go
+++ b/pkg/form3/payments_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestQueryPayments(t *testing.T) {
+	skipWhenCredentialsMissing(t)
+
 	f3, err := form3.NewFromEnv()
 	require.NoError(t, err)
 
@@ -22,6 +24,8 @@ func TestQueryPayments(t *testing.T) {
 }
 
 func TestPaymentFromJsonFile(t *testing.T) {
+	skipWhenCredentialsMissing(t)
+
 	f3, err := form3.NewFromEnv()
 	require.NoError(t, err)
 
@@ -34,6 +38,8 @@ func TestPaymentFromJsonFile(t *testing.T) {
 }
 
 func TestPaymentToJson(t *testing.T) {
+	skipWhenCredentialsMissing(t)
+
 	f3, err := form3.NewFromEnv()
 	require.NoError(t, err)
 

--- a/pkg/form3/subscriptions_test.go
+++ b/pkg/form3/subscriptions_test.go
@@ -62,6 +62,8 @@ func TestCreateSubscriptionsNewCallbackUriParamsHttpAwsPrivate(t *testing.T) {
 }
 
 func testCreateAndUpdateSubscriptions(t *testing.T, attributes *models.SubscriptionAttributes) {
+	skipWhenCredentialsMissing(t)
+
 	f3, err := form3.NewFromEnv()
 	require.NoError(t, err)
 
@@ -103,6 +105,8 @@ func testCreateAndUpdateSubscriptions(t *testing.T, attributes *models.Subscript
 }
 
 func TestListSubscriptions(t *testing.T) {
+	skipWhenCredentialsMissing(t)
+
 	f3, err := form3.NewFromEnv()
 	require.NoError(t, err)
 

--- a/pkg/generated/models/callback_transport.go
+++ b/pkg/generated/models/callback_transport.go
@@ -32,6 +32,9 @@ const (
 
 	// CallbackTransportHTTPGcpPrivate captures enum value "http_gcp_private"
 	CallbackTransportHTTPGcpPrivate CallbackTransport = "http_gcp_private"
+
+	// CallbackTransportHTTPAzurePrivate captures enum value "http_azure_private"
+	CallbackTransportHTTPAzurePrivate CallbackTransport = "http_azure_private"
 )
 
 // for schema
@@ -39,7 +42,7 @@ var callbackTransportEnum []interface{}
 
 func init() {
 	var res []CallbackTransport
-	if err := json.Unmarshal([]byte(`["queue","http","http_aws_private","http_gcp_private"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["queue","http","http_aws_private","http_gcp_private","http_azure_private"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {


### PR DESCRIPTION
Adding `http_azure_private` callback transport for subscriptions. 


# Proof of Work

![Screenshot 2024-06-27 at 12 38 27](https://github.com/form3tech-oss/go-form3/assets/108660777/badba0ec-11d9-4aaa-ac40-6974669e915a)
