### PR TITLE
fix: use the requests content-type for request signing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v3.5.0
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version-file: 'go.mod'
       - name: Run tests

--- a/pkg/form3/auth_request_signing.go
+++ b/pkg/form3/auth_request_signing.go
@@ -8,7 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -87,7 +87,7 @@ date: %s`,
 		req.Method == http.MethodPut ||
 		req.Method == http.MethodPatch) &&
 		req.Body != nil {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error reading request body: %w", err)
 		}
@@ -96,20 +96,26 @@ date: %s`,
 			return nil, fmt.Errorf("error hashing: %w", err)
 		}
 		digest := base64.StdEncoding.EncodeToString(hasher.Sum(nil))
+		contentType := req.Header.Get("Content-Type")
+		if contentType == "" {
+			contentType = ReqMimeType
+		}
+		contentLength := int64(len(body))
 
 		msgToSign += fmt.Sprintf(`
 content-type: %s
 digest: SHA-256=%s
 content-length: %d`,
-			ReqMimeType,
+			contentType,
 			digest,
-			req.ContentLength,
+			contentLength,
 		)
 
 		headers = append(headers, "content-type", "digest", "content-length")
 
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
-		req.Header.Set("Content-Type", ReqMimeType)
+		req.Body = io.NopCloser(bytes.NewBuffer(body))
+		req.ContentLength = contentLength
+		req.Header.Set("Content-Type", contentType)
 		req.Header.Set("Digest", digest)
 	}
 

--- a/pkg/form3/auth_request_signing_test.go
+++ b/pkg/form3/auth_request_signing_test.go
@@ -2,13 +2,18 @@ package form3_test
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/form3tech-oss/go-form3/v7/pkg/form3"
@@ -16,6 +21,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestRequestSigningAuth(t *testing.T) {
 	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -102,4 +113,149 @@ func TestWithUserAgent(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestRequestSigningTransportPOSTJSONBodySigning(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pubKeyID, err := uuid.Parse("9cdc44af-479c-45a7-9973-07b5b8608d11")
+	require.NoError(t, err)
+
+	body := []byte(`{"data":{"type":"payments"}}`)
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/payments", bytes.NewReader(body))
+	require.NoError(t, err)
+
+	tr := form3.NewRequestSigningTransport(
+		form3.WithPrivateKey(privKey),
+		form3.WithPublicKeyID(pubKeyID),
+		form3.WithUnderlyingRequestSigningTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			msgToSign := assertSignedRequest(t, req, &privKey.PublicKey)
+
+			assert.Equal(t, form3.ReqMimeType, req.Header.Get("Content-Type"))
+			assert.Equal(t, expectedDigest(body), req.Header.Get("Digest"))
+			assert.Equal(t, int64(len(body)), req.ContentLength)
+			assert.Contains(t, req.Header.Get("Authorization"), `headers="(request-target) host date content-type digest content-length"`)
+			assert.Contains(t, msgToSign, "content-type: "+form3.ReqMimeType)
+			assert.Contains(t, msgToSign, fmt.Sprintf("content-length: %d", len(body)))
+
+			gotBody, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			assert.Equal(t, body, gotBody)
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		})),
+	)
+
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+}
+
+func TestRequestSigningTransportPOSTMultipartBodySigning(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pubKeyID, err := uuid.Parse("9cdc44af-479c-45a7-9973-07b5b8608d11")
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	require.NoError(t, writer.WriteField("name", "value"))
+	require.NoError(t, writer.Close())
+
+	body := buf.Bytes()
+	contentType := writer.FormDataContentType()
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/files", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", contentType)
+	req.ContentLength = -1
+
+	tr := form3.NewRequestSigningTransport(
+		form3.WithPrivateKey(privKey),
+		form3.WithPublicKeyID(pubKeyID),
+		form3.WithUnderlyingRequestSigningTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			msgToSign := assertSignedRequest(t, req, &privKey.PublicKey)
+
+			assert.Equal(t, contentType, req.Header.Get("Content-Type"))
+			assert.Equal(t, expectedDigest(body), req.Header.Get("Digest"))
+			assert.Equal(t, int64(len(body)), req.ContentLength)
+			assert.Contains(t, msgToSign, "content-type: "+contentType)
+			assert.Contains(t, msgToSign, fmt.Sprintf("content-length: %d", len(body)))
+			assert.NotContains(t, msgToSign, "content-type: "+form3.ReqMimeType)
+
+			gotBody, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			assert.Equal(t, body, gotBody)
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		})),
+	)
+
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+}
+
+func assertSignedRequest(t *testing.T, req *http.Request, publicKey *rsa.PublicKey) string {
+	t.Helper()
+
+	msgToSign, signature := signedMessageAndSignature(t, req)
+	hashed := sha256.Sum256([]byte(msgToSign))
+
+	err := rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, hashed[:], signature)
+	require.NoError(t, err)
+
+	return msgToSign
+}
+
+func signedMessageAndSignature(t *testing.T, req *http.Request) (string, []byte) {
+	t.Helper()
+
+	authHeader := req.Header.Get("Authorization")
+	reg := regexp.MustCompile(`headers="([^"]+)".*signature="([^"]+)"`)
+	matches := reg.FindStringSubmatch(authHeader)
+	require.Len(t, matches, 3, "authorization header missing signed headers or signature")
+
+	headers := strings.Split(matches[1], " ")
+	lines := make([]string, 0, len(headers))
+	for _, header := range headers {
+		switch header {
+		case "(request-target)":
+			lines = append(lines, fmt.Sprintf("(request-target): %s %s", strings.ToLower(req.Method), req.URL.RequestURI()))
+		case "host":
+			lines = append(lines, "host: "+req.URL.Host)
+		case "date":
+			lines = append(lines, "date: "+req.Header.Get("Date"))
+		case "content-type":
+			lines = append(lines, "content-type: "+req.Header.Get("Content-Type"))
+		case "digest":
+			lines = append(lines, "digest: SHA-256="+req.Header.Get("Digest"))
+		case "content-length":
+			lines = append(lines, fmt.Sprintf("content-length: %d", req.ContentLength))
+		default:
+			t.Fatalf("unexpected signed header %q", header)
+		}
+	}
+
+	signature, err := base64.StdEncoding.DecodeString(matches[2])
+	require.NoError(t, err)
+
+	return strings.Join(lines, "\n"), signature
+}
+
+func expectedDigest(body []byte) string {
+	sum := sha256.Sum256(body)
+	return base64.StdEncoding.EncodeToString(sum[:])
 }


### PR DESCRIPTION
## Summary

Request signing always used `application/vnd.api+json` and `req.ContentLength`, which broke multipart and other non-JSON bodies. Sign and set headers from the actual body bytes and the request's Content-Type (defaulting when unset). Replace deprecated `ioutil` with `io`.

## Proof of work

```
 ~/dev/projects/form3-oss/go-form3 > tl-req-sign-content-type $ make test
go test -v -race -cover ./pkg/form3
=== RUN   TestRequestSigningAuth
--- PASS: TestRequestSigningAuth (0.28s)
=== RUN   TestWithUserAgent
=== RUN   TestWithUserAgent/Default
=== RUN   TestWithUserAgent/Custom_User_Agent
--- PASS: TestWithUserAgent (0.41s)
    --- PASS: TestWithUserAgent/Default (0.00s)
    --- PASS: TestWithUserAgent/Custom_User_Agent (0.00s)
=== RUN   TestRequestSigningTransportPOSTJSONBodySigning
--- PASS: TestRequestSigningTransportPOSTJSONBodySigning (0.19s)
=== RUN   TestRequestSigningTransportPOSTMultipartBodySigning
--- PASS: TestRequestSigningTransportPOSTMultipartBodySigning (0.35s)
=== RUN   TestTokenAuth
--- PASS: TestTokenAuth (0.59s)
=== RUN   TestMTLS
--- PASS: TestMTLS (0.02s)
=== RUN   TestQueryPayments
--- PASS: TestQueryPayments (0.74s)
=== RUN   TestPaymentFromJsonFile
--- PASS: TestPaymentFromJsonFile (0.00s)
=== RUN   TestPaymentToJson
--- PASS: TestPaymentToJson (0.00s)
=== RUN   Test_ResponseInterface
--- PASS: Test_ResponseInterface (0.00s)
=== RUN   TestCreateSubscriptionsDeprecatedCallbackUriParams
--- PASS: TestCreateSubscriptionsDeprecatedCallbackUriParams (0.28s)
=== RUN   TestCreateSubscriptionsNewCallbackUriParams
--- PASS: TestCreateSubscriptionsNewCallbackUriParams (0.26s)
=== RUN   TestCreateSubscriptionsNewCallbackUriParamsHttpAwsPrivate
--- PASS: TestCreateSubscriptionsNewCallbackUriParamsHttpAwsPrivate (0.26s)
=== RUN   TestListSubscriptions
--- PASS: TestListSubscriptions (0.08s)
PASS
coverage: 77.1% of statements
ok      github.com/form3tech-oss/go-form3/v7/pkg/form3  5.037s  coverage: 77.1% of statements
```